### PR TITLE
Improve the code for downloading cover images

### DIFF
--- a/bookish/src/add_review.rs
+++ b/bookish/src/add_review.rs
@@ -5,7 +5,7 @@
 
 use std::fs;
 use std::fs::OpenOptions;
-use std::io::{Cursor, Write};
+use std::io::Write;
 use std::process::Command;
 
 use chrono::Datelike;
@@ -145,16 +145,12 @@ pub fn add_review() -> () {
 
     let cover_url = get_url_value("What's the cover URL?");
 
-    let resp = reqwest::blocking::get(cover_url.as_str()).unwrap();
-
     let extension = cover_url.path().split(".").last().unwrap();
     let slug = text::slugify(&title);
     let cover_name = format!("{}.{}", slug, extension);
     let cover_path = format!("src/covers/{}", &cover_name);
 
-    let mut file = std::fs::File::create(&cover_path).unwrap();
-    let mut content =  Cursor::new(resp.bytes().unwrap());
-    std::io::copy(&mut content, &mut file).unwrap();
+    urls::download_url(&cover_url, &cover_path).unwrap();
 
     let cover_size = fs::metadata(&cover_path).unwrap().len();
 

--- a/bookish/src/add_review.rs
+++ b/bookish/src/add_review.rs
@@ -150,7 +150,10 @@ pub fn add_review() -> () {
     let cover_name = format!("{}.{}", slug, extension);
     let cover_path = format!("src/covers/{}", &cover_name);
 
-    urls::download_url(&cover_url, &cover_path).unwrap();
+    urls::download_url(&cover_url, &cover_path).unwrap_or_else(|e| {
+        eprintln!("{}", e);
+        std::process::exit(1);
+    });
 
     let cover_size = fs::metadata(&cover_path).unwrap().len();
 

--- a/bookish/src/urls.rs
+++ b/bookish/src/urls.rs
@@ -6,11 +6,30 @@ pub fn is_url(s: &str) -> bool {
     Url::parse(s).is_ok()
 }
 
-pub fn download_url(url: &Url, download_path: &str) -> Result<(), String> {
-    let resp = reqwest::blocking::get(url.as_str()).unwrap();
+/// Download the contents of a URL to a local path.
+///
+/// This function assumes the HTTP request may fail, but everyone on the local
+/// filesystem will be fine.  In particular, it returns an Err<reqwest::Error>
+/// if the HTTP request fails, but it panics if something goes wrong writing
+/// successfully fetched bytes to a file.
+///
+pub fn download_url(url: &Url, download_path: &str) -> Result<(), reqwest::Error> {
 
+    // Return an error if the GET request completely fails, e.g. if we can't
+    // connect to the network at all.
+    let resp = reqwest::blocking::get(url.as_str())?;
+
+    // Return an error if we don't get a 200 OK status code.
+    let resp = resp.error_for_status()?;
+
+    // Assuming we made a successful request, write the bytes of the response
+    // to a file.
+    //
+    // Ideally I wouldn't be using quite so much unwrap() here, but as we're
+    // doing operations on the local filesystem and within a known-safe directory
+    // (i.e. the "src" folder of this repository), it's probably fine.
     let mut file = std::fs::File::create(download_path).unwrap();
-    let mut content =  Cursor::new(resp.bytes().unwrap());
+    let mut content = Cursor::new(resp.bytes()?);
     std::io::copy(&mut content, &mut file).unwrap();
 
     Ok(())

--- a/bookish/src/urls.rs
+++ b/bookish/src/urls.rs
@@ -1,7 +1,19 @@
+use std::io::Cursor;
+
 use url::Url;
 
 pub fn is_url(s: &str) -> bool {
     Url::parse(s).is_ok()
+}
+
+pub fn download_url(url: &Url, download_path: &str) -> Result<(), String> {
+    let resp = reqwest::blocking::get(url.as_str()).unwrap();
+
+    let mut file = std::fs::File::create(download_path).unwrap();
+    let mut content =  Cursor::new(resp.bytes().unwrap());
+    std::io::copy(&mut content, &mut file).unwrap();
+
+    Ok(())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
In particular if there's any error downloading the image (e.g. a 401 Not Authorised; see #403), we now flag that to the user rather than letting it pass silently.