### PR TITLE
Fix a bug where sometimes covers wouldn't download correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.3.3 - 2022-03-30
+
+Fix a bug where sometimes covers wouldn't download correctly when adding a review.
+
 ## v1.3.2 - 2022-03-30
 
 Fix a bug where the Netlify builds process wasn't picking up the `_redirects` file.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2708,7 +2708,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vfd"
-version = "1.3.2"
+version = "1.3.3"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfd"
-version = "1.3.2"
+version = "1.3.3"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
In particular, if the URL didn't have a file extension, the code would guess a completely nonsensical name for the cover path, e.g. if the URL was

    https://example.org/images/books/cover-of-this-book

then it would try to download the image with the name

    org/images/books/cover-of-this-book

which caused a "file not found error" because there's no `org/images/books` directory to download the image into.

This patch modifies the download code so it uses the HTTP Content-Type header to decide what file extension to use, rather than the URL.

It's probably still a bit flaky, but it fixes the immediate problem I was having tonight and should be a better foundation for future work.