### PR TITLE
Improve the way CSS is handled

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -211,11 +211,6 @@ footer a:hover {
   width: 50px;
 }
 
-/* TODO: Do I still want this? */
-#jump_to {
-  margin-bottom: -0.5em;
-}
-
 .star_rating {
   font-size: 100%;
   letter-spacing: 4px;
@@ -238,7 +233,7 @@ footer a:hover {
     grid-template-columns: auto;
   }
 
-  .review_preview img, .reading_inner img {
+  .review_preview img {
     max-width: 250px;
     max-height: 150px;
     margin-top: 15px;

--- a/templates/base.html
+++ b/templates/base.html
@@ -8,7 +8,7 @@
       TODO: Implement cache invalidation when the CSS file changes.
       I dropped it in the Rust rewrite, but it needs sorting.
     -->
-    <link rel="stylesheet" href="/static/style.css">
+    <link rel="stylesheet" href="/static/style.css?t={{ now() | date(format="%s") }}">
     <style>
       {% include "_base.css" %}
 


### PR DESCRIPTION
For #34

In particular, the template now adds a timestamp parameter to the CSS stylesheet, so clients will be forced to fetch it after every build. This isn't ideal – it means clients will refetch it even when it hasn't changed – but it's better than the alternative, which is browsers not fetching CSS when it changes.