### PR TITLE
Don't include the cover size in the book front-matter

### DIFF
--- a/reviews/2003/harry-potter-and-the-order-of-the-phoenix.md
+++ b/reviews/2003/harry-potter-and-the-order-of-the-phoenix.md
@@ -3,7 +3,6 @@ book:
   author: J. K. Rowling
   cover:
     name: harry-potter-and-the-order-of-the-phoenix.jpg
-    size: 40992
     tint_color: "#f2b63a"
   publication_year: 2005
   title: Harry Potter and the Order of the Phoenix

--- a/reviews/2005/harry-potter-and-the-half-blood-prince.md
+++ b/reviews/2005/harry-potter-and-the-half-blood-prince.md
@@ -3,7 +3,6 @@ book:
   author: J. K. Rowling
   cover:
     name: harry-potter-and-the-half-blood-prince.jpg
-    size: 228511
     tint_color: "#322824"
   publication_year: 2005
   title: Harry Potter and the Half-Blood Prince

--- a/reviews/2007/harry-potter-and-the-deathly-hallows.md
+++ b/reviews/2007/harry-potter-and-the-deathly-hallows.md
@@ -3,7 +3,6 @@ book:
   author: J. K. Rowling
   cover:
     name: harry-potter-and-the-deathly-hallows.jpg
-    size: 262952
     tint_color: "#06121a"
   publication_year: 2007
   title: Harry Potter and the Deathly Hallows

--- a/reviews/2011/cryptography-a-very-short-introduction.md
+++ b/reviews/2011/cryptography-a-very-short-introduction.md
@@ -3,7 +3,6 @@ book:
   author: Fred C. Piper
   cover:
     name: cryptography-a-very-short-introduction.jpg
-    size: 6333
     tint_color: '#955943'
   isbn10: 0192803158
   isbn13: '9780192803153'

--- a/reviews/2011/enigma-the-battle-for-the-code.md
+++ b/reviews/2011/enigma-the-battle-for-the-code.md
@@ -3,7 +3,6 @@ book:
   author: Hugh Sebag-Montefiore
   cover:
     name: enigma-the-battle-for-the-code.jpg
-    size: 11681
     tint_color: '#b92e3d'
   isbn10: '0304366625'
   isbn13: '9780304366620'

--- a/reviews/2011/five-equations-that-changed-the-world.md
+++ b/reviews/2011/five-equations-that-changed-the-world.md
@@ -3,7 +3,6 @@ book:
   author: Michael Guillen
   cover:
     name: five-equations-that-changed-the-world.jpg
-    size: 15063
     tint_color: '#8f584e'
   isbn10: '1567314058'
   isbn13: '9781567314052'

--- a/reviews/2011/focus.md
+++ b/reviews/2011/focus.md
@@ -3,7 +3,6 @@ book:
   author: Leo Babauta
   cover:
     name: focus.png
-    size: 9092
     tint_color: '#6a696b'
   isbn10: ''
   isbn13: ''

--- a/reviews/2011/how-many-lightbulbs-does-it-take-to-change-a-planet.md
+++ b/reviews/2011/how-many-lightbulbs-does-it-take-to-change-a-planet.md
@@ -3,7 +3,6 @@ book:
   author: Tony Juniper
   cover:
     name: how-many-lightbulbs-does-it-take-to-change-a-planet.jpg
-    size: 12963
     tint_color: '#a03c37'
   isbn10: '1847240496'
   isbn13: '9781847240491'

--- a/reviews/2011/march-hares-and-monkeys-uncles.md
+++ b/reviews/2011/march-hares-and-monkeys-uncles.md
@@ -3,7 +3,6 @@ book:
   author: Harry Oliver
   cover:
     name: march-hares-and-monkeys-uncles.jpg
-    size: 9622
     tint_color: '#bb233d'
   isbn10: '1843581523'
   isbn13: '9781843581529'

--- a/reviews/2011/the-last-little-blue-envelope.md
+++ b/reviews/2011/the-last-little-blue-envelope.md
@@ -3,7 +3,6 @@ book:
   author: Maureen Johnson
   cover:
     name: the-last-little-blue-envelope.jpg
-    size: 10059
     tint_color: '#d22c2d'
   isbn10: 0061976792
   isbn13: '9780061976797'

--- a/reviews/2011/the-never-ending-days-of-being-dead.md
+++ b/reviews/2011/the-never-ending-days-of-being-dead.md
@@ -3,7 +3,6 @@ book:
   author: Marcus Chown
   cover:
     name: the-never-ending-days-of-being-dead.jpg
-    size: 10931
     tint_color: '#9d565e'
   isbn10: 0571220568
   isbn13: '9780571220564'

--- a/reviews/2011/twos-company-three-is-complexity.md
+++ b/reviews/2011/twos-company-three-is-complexity.md
@@ -3,7 +3,6 @@ book:
   author: Neil Johnson
   cover:
     name: twos-company-three-is-complexity.jpg
-    size: 10823
     tint_color: '#445c84'
   isbn10: '1851684883'
   isbn13: '9781851684885'

--- a/reviews/2015/a-little-book-of-language.md
+++ b/reviews/2015/a-little-book-of-language.md
@@ -3,7 +3,6 @@ book:
   author: David Crystal
   cover:
     name: a-little-book-of-language.jpg
-    size: 8368
     tint_color: '#77766e'
   isbn10: 0300170823
   isbn13: '9780300170825'

--- a/reviews/2015/carmilla.md
+++ b/reviews/2015/carmilla.md
@@ -3,7 +3,6 @@ book:
   author: J. Sheridan Le Fanu
   cover:
     name: carmilla.jpg
-    size: 7409
     tint_color: '#000000'
   publication_year: 1872
   title: Carmilla

--- a/reviews/2015/effective-python.md
+++ b/reviews/2015/effective-python.md
@@ -3,7 +3,6 @@ book:
   author: Brett Slatkin
   cover:
     name: effective-python.jpg
-    size: 6703
     tint_color: '#222021'
   isbn10: 0134034287
   isbn13: '9780134034287'

--- a/reviews/2015/just-my-type.md
+++ b/reviews/2015/just-my-type.md
@@ -3,7 +3,6 @@ book:
   author: Simon Garfield
   cover:
     name: just-my-type.jpg
-    size: 9408
     tint_color: '#3e7b89'
   isbn10: '1846683017'
   isbn13: '9781846683015'

--- a/reviews/2015/operation-fortitude-the-greatest-hoax-of-the-second-world-war.md
+++ b/reviews/2015/operation-fortitude-the-greatest-hoax-of-the-second-world-war.md
@@ -3,7 +3,6 @@ book:
   author: Joshua Levine
   cover:
     name: operation-fortitude-the-greatest-hoax-of-the-second-world-war.jpg
-    size: 9722
     tint_color: '#d60812'
   isbn10: 0007395876
   isbn13: '9780007395873'

--- a/reviews/2015/paper-towns.md
+++ b/reviews/2015/paper-towns.md
@@ -3,7 +3,6 @@ book:
   author: John Green
   cover:
     name: paper-towns.jpg
-    size: 6619
     tint_color: '#b51025'
   isbn10: 014241493X
   isbn13: '9780142414934'

--- a/reviews/2015/secrets-of-the-conqueror-the-untold-story-of-britains-most-famous-submarine.md
+++ b/reviews/2015/secrets-of-the-conqueror-the-untold-story-of-britains-most-famous-submarine.md
@@ -3,7 +3,6 @@ book:
   author: Stuart Prebble
   cover:
     name: secrets-of-the-conqueror-the-untold-story-of-britains-most-famous-submarine.jpg
-    size: 9950
     tint_color: '#b84146'
   isbn10: 0571290337
   isbn13: '9780571290338'

--- a/reviews/2015/target-tirpitz.md
+++ b/reviews/2015/target-tirpitz.md
@@ -3,7 +3,6 @@ book:
   author: Patrick Bishop
   cover:
     name: target-tirpitz.jpg
-    size: 9665
     tint_color: '#e30f0e'
   isbn10: 000731924X
   isbn13: '9780007319244'

--- a/reviews/2015/the-long-dark-tea-time-of-the-soul.md
+++ b/reviews/2015/the-long-dark-tea-time-of-the-soul.md
@@ -3,7 +3,6 @@ book:
   author: Douglas Adams
   cover:
     name: the-long-dark-tea-time-of-the-soul.jpg
-    size: 11040
     tint_color: '#89321c'
   isbn10: '1447221109'
   isbn13: '9781447221104'

--- a/reviews/2015/you-say-potato.md
+++ b/reviews/2015/you-say-potato.md
@@ -3,7 +3,6 @@ book:
   author: Ben Crystal, David Crystal
   cover:
     name: you-say-potato.jpg
-    size: 7019
     tint_color: '#006eb3'
   isbn10: '1447249690'
   isbn13: '9781447249696'

--- a/reviews/2016/a-philosophy-of-walking.md
+++ b/reviews/2016/a-philosophy-of-walking.md
@@ -3,7 +3,6 @@ book:
   author: Frédéric Gros
   cover:
     name: a-philosophy-of-walking.jpg
-    size: 8134
     tint_color: '#6c7b4e'
   isbn10: '1781682704'
   isbn13: '9781781682708'

--- a/reviews/2016/adventures-with-the-wife-in-space.md
+++ b/reviews/2016/adventures-with-the-wife-in-space.md
@@ -3,7 +3,6 @@ book:
   author: Neil Perryman
   cover:
     name: adventures-with-the-wife-in-space.jpg
-    size: 9029
     tint_color: '#5d5a71'
   isbn10: 0571298109
   isbn13: '9780571298105'

--- a/reviews/2016/blind-mans-bluff.md
+++ b/reviews/2016/blind-mans-bluff.md
@@ -3,7 +3,6 @@ book:
   author: Sherry Sontag
   cover:
     name: blind-mans-bluff.jpg
-    size: 10269
     tint_color: '#5f7777'
   isbn10: 0099409984
   isbn13: '9780099409984'

--- a/reviews/2016/getting-things-done.md
+++ b/reviews/2016/getting-things-done.md
@@ -3,7 +3,6 @@ book:
   author: David Allen
   cover:
     name: getting-things-done.jpg
-    size: 18426
     tint_color: '#7b575c'
   isbn10: 0142000280
   isbn13: '9780142000281'

--- a/reviews/2016/master-pieces.md
+++ b/reviews/2016/master-pieces.md
@@ -3,7 +3,6 @@ book:
   author: Gareth Williams
   cover:
     name: master-pieces.jpg
-    size: 5379
     tint_color: '#557664'
   isbn10: '1840921536'
   isbn13: '9781840921533'

--- a/reviews/2016/shouldnt-you-be-in-school.md
+++ b/reviews/2016/shouldnt-you-be-in-school.md
@@ -3,7 +3,6 @@ book:
   author: Lemony Snicket
   cover:
     name: shouldnt-you-be-in-school.jpg
-    size: 19608
     tint_color: '#2474b8'
   isbn10: '0316123064'
   isbn13: '9780316123068'

--- a/reviews/2016/the-chronicles-of-narnia-audio-collection.md
+++ b/reviews/2016/the-chronicles-of-narnia-audio-collection.md
@@ -3,7 +3,6 @@ book:
   author: C.S. Lewis
   cover:
     name: the-chronicles-of-narnia-audio-collection.jpg
-    size: 13350
     tint_color: '#6d4f31'
   isbn10: 0694524662
   isbn13: '9780694524662'

--- a/reviews/2016/the-riddle-of-the-labyrinth.md
+++ b/reviews/2016/the-riddle-of-the-labyrinth.md
@@ -3,7 +3,6 @@ book:
   author: Margalit Fox
   cover:
     name: the-riddle-of-the-labyrinth.jpg
-    size: 9419
     tint_color: '#9d4b2b'
   isbn10: '1781251320'
   isbn13: '9781781251324'

--- a/reviews/2016/typography-for-lawyers.md
+++ b/reviews/2016/typography-for-lawyers.md
@@ -3,7 +3,6 @@ book:
   author: Matthew Butterick
   cover:
     name: typography-for-lawyers.jpg
-    size: 5383
     tint_color: '#6a6a6a'
   isbn10: 159839262X
   isbn13: '9781598392623'

--- a/reviews/2016/when-did-you-see-her-last.md
+++ b/reviews/2016/when-did-you-see-her-last.md
@@ -3,7 +3,6 @@ book:
   author: Lemony Snicket
   cover:
     name: when-did-you-see-her-last.jpg
-    size: 14474
     tint_color: '#8b6198'
   isbn10: '0316123056'
   isbn13: '9780316123051'

--- a/reviews/2016/who-could-that-be-at-this-hour.md
+++ b/reviews/2016/who-could-that-be-at-this-hour.md
@@ -3,7 +3,6 @@ book:
   author: Lemony Snicket
   cover:
     name: who-could-that-be-at-this-hour.jpg
-    size: 13282
     tint_color: '#bb4f1c'
   isbn10: 0316123080
   isbn13: '9780316123082'

--- a/reviews/2016/why-is-this-night-different-from-all-other-nights.md
+++ b/reviews/2016/why-is-this-night-different-from-all-other-nights.md
@@ -3,7 +3,6 @@ book:
   author: Lemony Snicket
   cover:
     name: why-is-this-night-different-from-all-other-nights.jpg
-    size: 12565
     tint_color: '#7f5ba0'
   isbn10: 0316123048
   isbn13: '9780316123044'

--- a/reviews/2017/a-closed-and-common-orbit.md
+++ b/reviews/2017/a-closed-and-common-orbit.md
@@ -3,7 +3,6 @@ book:
   author: Becky Chambers
   cover:
     name: a-closed-and-common-orbit.jpg
-    size: 7780
     tint_color: '#c31413'
   isbn10: '1473621445'
   isbn13: '9781473621442'

--- a/reviews/2017/await-your-reply.md
+++ b/reviews/2017/await-your-reply.md
@@ -3,7 +3,6 @@ book:
   author: Dan Chaon
   cover:
     name: await-your-reply.jpg
-    size: 6196
     tint_color: '#636874'
   isbn10: 0-345-47602-6
   isbn13: 978-0-345-47602-9

--- a/reviews/2017/doctor-who-timeless.md
+++ b/reviews/2017/doctor-who-timeless.md
@@ -3,7 +3,6 @@ book:
   author: Stephen Cole
   cover:
     name: doctor-who-timeless.jpg
-    size: 23190
     tint_color: '#1f5b95'
   isbn10: 0563486074
   isbn13: '9780563486077'

--- a/reviews/2017/fire-season.md
+++ b/reviews/2017/fire-season.md
@@ -3,7 +3,6 @@ book:
   author: Philip Connors
   cover:
     name: fire-season.jpg
-    size: 5660
     tint_color: '#854f26'
   isbn10: '1447208145'
   isbn13: '9781447208143'

--- a/reviews/2017/forgotten-sacrifice-the-arctic-convoys-of-world-war-ii.md
+++ b/reviews/2017/forgotten-sacrifice-the-arctic-convoys-of-world-war-ii.md
@@ -3,7 +3,6 @@ book:
   author: Michael G. Walling
   cover:
     name: forgotten-sacrifice-the-arctic-convoys-of-world-war-ii.jpg
-    size: 11826
     tint_color: '#5b6d7f'
   isbn10: '1849087180'
   isbn13: '9781849087186'

--- a/reviews/2017/granuaile-grace-omalley-irelands-pirate-queen.md
+++ b/reviews/2017/granuaile-grace-omalley-irelands-pirate-queen.md
@@ -3,7 +3,6 @@ book:
   author: Anne Chambers
   cover:
     name: granuaile-grace-omalley-irelands-pirate-queen.jpg
-    size: 9980
     tint_color: '#60616b'
   isbn10: 0717145824
   isbn13: '9780717145829'

--- a/reviews/2017/i-was-there-on-pq17-the-convoy-to-hell.md
+++ b/reviews/2017/i-was-there-on-pq17-the-convoy-to-hell.md
@@ -3,7 +3,6 @@ book:
   author: Paul Lund
   cover:
     name: i-was-there-on-pq17-the-convoy-to-hell.jpg
-    size: 10010
     tint_color: '#af4f31'
   isbn10: 057203542X
   isbn13: '9780572035426'

--- a/reviews/2017/last-chance-to-see.md
+++ b/reviews/2017/last-chance-to-see.md
@@ -3,7 +3,6 @@ book:
   author: Douglas Adams & Mark Carwadine
   cover:
     name: last-chance-to-see.jpg
-    size: 10940
     tint_color: '#ce1c1a'
   isbn10: 009953679X
   isbn13: '9780099536796'

--- a/reviews/2017/manx-fairy-tales.md
+++ b/reviews/2017/manx-fairy-tales.md
@@ -3,7 +3,6 @@ book:
   author: Sophia Morrison
   cover:
     name: manx-fairy-tales.jpg
-    size: 22863
     tint_color: '#506840'
   isbn10: 187312001X
   isbn13: '9781873120019'

--- a/reviews/2017/mind-the-gap-a-london-underground-miscellany.md
+++ b/reviews/2017/mind-the-gap-a-london-underground-miscellany.md
@@ -3,7 +3,6 @@ book:
   author: Emily Kearns
   cover:
     name: mind-the-gap-a-london-underground-miscellany.jpg
-    size: 6789
     tint_color: '#e10518'
   isbn10: '1849533571'
   isbn13: '9781849533577'

--- a/reviews/2017/numbers-rule-the-vexing-mathematics-of-democracy-from-plato-to-the-present.md
+++ b/reviews/2017/numbers-rule-the-vexing-mathematics-of-democracy-from-plato-to-the-present.md
@@ -3,7 +3,6 @@ book:
   author: George G. Szpiro
   cover:
     name: numbers-rule-the-vexing-mathematics-of-democracy-from-plato-to-the-present.jpg
-    size: 9528
     tint_color: '#a4543e'
   isbn10: 0691139946
   isbn13: '9780691139944'

--- a/reviews/2017/psychiatric-tales.md
+++ b/reviews/2017/psychiatric-tales.md
@@ -3,7 +3,6 @@ book:
   author: Darryl Cunningham
   cover:
     name: psychiatric-tales.jpg
-    size: 6208
     tint_color: '#686868'
   isbn10: '1906653089'
   isbn13: '9781906653088'

--- a/reviews/2017/the-curious-incident-of-the-dog-in-the-night-time.md
+++ b/reviews/2017/the-curious-incident-of-the-dog-in-the-night-time.md
@@ -3,7 +3,6 @@ book:
   author: Mark Haddon
   cover:
     name: the-curious-incident-of-the-dog-in-the-night-time.jpg
-    size: 9205
     tint_color: '#bb422f'
   isbn10: 0099450259
   isbn13: '9780099450252'

--- a/reviews/2017/the-dark.md
+++ b/reviews/2017/the-dark.md
@@ -3,7 +3,6 @@ book:
   author: Lemony Snicket
   cover:
     name: the-dark.jpg
-    size: 5308
     tint_color: '#000000'
   isbn10: 0316187488
   isbn13: '9780316187480'

--- a/reviews/2017/the-examined-life-how-we-lose-and-find-ourselves.md
+++ b/reviews/2017/the-examined-life-how-we-lose-and-find-ourselves.md
@@ -3,7 +3,6 @@ book:
   author: Stephen Grosz
   cover:
     name: the-examined-life-how-we-lose-and-find-ourselves.jpg
-    size: 5421
     tint_color: '#716361'
   isbn10: 0393349322
   isbn13: '9780393349320'

--- a/reviews/2017/the-healthy-programmer.md
+++ b/reviews/2017/the-healthy-programmer.md
@@ -3,7 +3,6 @@ book:
   author: Joe Kutner
   cover:
     name: the-healthy-programmer.jpg
-    size: 3839
     tint_color: '#2773b0'
   isbn10: '1937785319'
   isbn13: '9781937785314'

--- a/reviews/2017/the-indisputable-existence-of-santa-claus.md
+++ b/reviews/2017/the-indisputable-existence-of-santa-claus.md
@@ -3,7 +3,6 @@ book:
   author: Dr Hannah Fry & Dr Thomas Oléron Evans
   cover:
     name: the-indisputable-existence-of-santa-claus.jpg
-    size: 7802
     tint_color: '#010101'
   publication_year: 2016
   title: The Indisputable Existence of Santa Claus

--- a/reviews/2017/the-long-way-to-a-small-angry-planet.md
+++ b/reviews/2017/the-long-way-to-a-small-angry-planet.md
@@ -3,7 +3,6 @@ book:
   author: Becky Chambers
   cover:
     name: the-long-way-to-a-small-angry-planet.jpg
-    size: 4324
     tint_color: '#6c6f84'
   isbn10: '1473619807'
   isbn13: '9781473619807'

--- a/reviews/2017/the-man-who-invented-the-daleks.md
+++ b/reviews/2017/the-man-who-invented-the-daleks.md
@@ -3,7 +3,6 @@ book:
   author: Alwyn W. Turner
   cover:
     name: the-man-who-invented-the-daleks.jpg
-    size: 9437
     tint_color: '#804034'
   isbn10: '1845136098'
   isbn13: '9781845136093'

--- a/reviews/2017/the-secret-listeners.md
+++ b/reviews/2017/the-secret-listeners.md
@@ -3,7 +3,6 @@ book:
   author: Sinclair McKay
   cover:
     name: the-secret-listeners.jpg
-    size: 21219
     tint_color: '#c14d4b'
   isbn13: '9781845137632'
   publication_year: 2012

--- a/reviews/2017/the-thrilling-adventures-of-lovelace-and-babbage.md
+++ b/reviews/2017/the-thrilling-adventures-of-lovelace-and-babbage.md
@@ -3,7 +3,6 @@ book:
   author: Sydney Padua
   cover:
     name: the-thrilling-adventures-of-lovelace-and-babbage.jpg
-    size: 12356
     tint_color: '#6d7472'
   isbn10: 0141981512
   isbn13: '9780141981512'

--- a/reviews/2017/the-wrong-kind-of-snow-how-the-weather-made-britain.md
+++ b/reviews/2017/the-wrong-kind-of-snow-how-the-weather-made-britain.md
@@ -3,7 +3,6 @@ book:
   author: Rob Penn
   cover:
     name: the-wrong-kind-of-snow-how-the-weather-made-britain.jpg
-    size: 12952
     tint_color: '#5f717a'
   isbn10: 0340937882
   isbn13: '9780340937884'

--- a/reviews/2017/too-much-information-or-can-everyone-just-shut-up-for-a-moment-some-of-us-are-trying-to-think.md
+++ b/reviews/2017/too-much-information-or-can-everyone-just-shut-up-for-a-moment-some-of-us-are-trying-to-think.md
@@ -3,7 +3,6 @@ book:
   author: Dave Gorman
   cover:
     name: too-much-information-or-can-everyone-just-shut-up-for-a-moment-some-of-us-are-trying-to-think.jpg
-    size: 11934
     tint_color: '#667849'
   isbn10: 0091928508
   isbn13: '9780091928506'

--- a/reviews/2017/turing-pioneer-of-the-information-age.md
+++ b/reviews/2017/turing-pioneer-of-the-information-age.md
@@ -3,7 +3,6 @@ book:
   author: B. Jack Copeland
   cover:
     name: turing-pioneer-of-the-information-age.jpg
-    size: 9899
     tint_color: '#883638'
   isbn10: 0199639795
   isbn13: '9780199639793'

--- a/reviews/2017/understanding-asexuality.md
+++ b/reviews/2017/understanding-asexuality.md
@@ -3,7 +3,6 @@ book:
   author: Anthony F. Bogaert
   cover:
     name: understanding-asexuality.jpg
-    size: 3549
     tint_color: '#69686f'
   isbn10: '1442200995'
   isbn13: '9781442200999'

--- a/reviews/2017/we-go-forward.md
+++ b/reviews/2017/we-go-forward.md
@@ -3,7 +3,6 @@ book:
   author: Alison Evans
   cover:
     name: we-go-forward.jpg
-    size: 4979
     tint_color: '#4d7790'
   isbn13: '9781620047255'
   publication_year: 2016

--- a/reviews/2017/what-if-serious-scientific-answers-to-absurd-hypothetical-questions.md
+++ b/reviews/2017/what-if-serious-scientific-answers-to-absurd-hypothetical-questions.md
@@ -3,7 +3,6 @@ book:
   author: Randall Munroe
   cover:
     name: what-if-serious-scientific-answers-to-absurd-hypothetical-questions.jpg
-    size: 13694
     tint_color: '#ad2f33'
   isbn10: 0544272994
   isbn13: '9780544272996'

--- a/reviews/2018/a-brief-history-of-wales.md
+++ b/reviews/2018/a-brief-history-of-wales.md
@@ -3,7 +3,6 @@ book:
   author: Gerald Morgan
   cover:
     name: a-brief-history-of-wales.jpg
-    size: 6030
     tint_color: '#000000'
   isbn10: '1847710182'
   isbn13: '9781847710185'

--- a/reviews/2018/a-little-book-about-the-runes.md
+++ b/reviews/2018/a-little-book-about-the-runes.md
@@ -3,7 +3,6 @@ book:
   author: Björn Jónasson
   cover:
     name: a-little-book-about-the-runes.jpg
-    size: 7793
     tint_color: '#70492f'
   isbn10: '9979856386'
   isbn13: '9789979856382'

--- a/reviews/2018/an-astronauts-guide-to-life-on-earth.md
+++ b/reviews/2018/an-astronauts-guide-to-life-on-earth.md
@@ -3,7 +3,6 @@ book:
   author: Chris Hadfield
   cover:
     name: an-astronauts-guide-to-life-on-earth.jpg
-    size: 10390
     tint_color: '#306089'
   isbn10: '1447257103'
   isbn13: '9781447257103'

--- a/reviews/2018/an-unsuitable-job-for-a-woman.md
+++ b/reviews/2018/an-unsuitable-job-for-a-woman.md
@@ -3,7 +3,6 @@ book:
   author: P.D. James
   cover:
     name: an-unsuitable-job-for-a-woman.jpg
-    size: 8666
     tint_color: '#cc181f'
   isbn10: '0571253407'
   isbn13: '9780571253401'

--- a/reviews/2018/and-another-thing.md
+++ b/reviews/2018/and-another-thing.md
@@ -3,7 +3,6 @@ book:
   author: Eoin Colfer
   cover:
     name: and-another-thing.jpg
-    size: 9012
     tint_color: '#a53829'
   isbn10: '1401323588'
   isbn13: '9781401323585'

--- a/reviews/2018/death-dynamite-and-disaster.md
+++ b/reviews/2018/death-dynamite-and-disaster.md
@@ -3,7 +3,6 @@ book:
   author: Rosa Matheson
   cover:
     name: death-dynamite-and-disaster.jpg
-    size: 15100
     tint_color: '#8b421b'
   isbn10: 0752492667
   isbn13: '9780752492667'

--- a/reviews/2018/eleanor-oliphant-is-completely-fine.md
+++ b/reviews/2018/eleanor-oliphant-is-completely-fine.md
@@ -3,7 +3,6 @@ book:
   author: Gail Honeyman
   cover:
     name: eleanor-oliphant-is-completely-fine.jpg
-    size: 7704
     tint_color: '#6d6a67'
   isbn10: 0008172145
   isbn13: '9780008172145'

--- a/reviews/2018/engines-of-war.md
+++ b/reviews/2018/engines-of-war.md
@@ -3,7 +3,6 @@ book:
   author: Christian Wolmarr
   cover:
     name: engines-of-war.jpg
-    size: 11618
     tint_color: '#b5303b'
   isbn10: '1848871724'
   isbn13: '9781848871724'

--- a/reviews/2018/hello-world-how-to-be-human-in-the-age-of-the-machine.md
+++ b/reviews/2018/hello-world-how-to-be-human-in-the-age-of-the-machine.md
@@ -3,7 +3,6 @@ book:
   author: Hannah Fry
   cover:
     name: hello-world-how-to-be-human-in-the-age-of-the-machine.jpg
-    size: 10023
     tint_color: '#000000'
   isbn10: 0857525247
   isbn13: '9780857525246'

--- a/reviews/2018/hidden-figures-the-untold-story-of-the-african-american-women-who-helped-win-the-space-race.md
+++ b/reviews/2018/hidden-figures-the-untold-story-of-the-african-american-women-who-helped-win-the-space-race.md
@@ -3,7 +3,6 @@ book:
   author: Margot Lee Shetterly
   cover:
     name: hidden-figures-the-untold-story-of-the-african-american-women-who-helped-win-the-space-race.jpg
-    size: 10828
     tint_color: '#444d74'
   publication_year: 2017
   title: 'Hidden Figures: The Untold Story of the African American Women Who Helped

--- a/reviews/2018/hyperbole-and-a-half.md
+++ b/reviews/2018/hyperbole-and-a-half.md
@@ -3,7 +3,6 @@ book:
   author: Allie Brosh
   cover:
     name: hyperbole-and-a-half.jpg
-    size: 11419
     tint_color: '#544f3d'
   isbn10: 0224095374
   isbn13: '9780224095372'

--- a/reviews/2018/i-hate-everyone-but-you.md
+++ b/reviews/2018/i-hate-everyone-but-you.md
@@ -3,7 +3,6 @@ book:
   author: Gaby Dunn & Allison Raskin
   cover:
     name: i-hate-everyone-but-you.jpg
-    size: 11598
     tint_color: '#823b44'
   isbn10: 125012932X
   isbn13: '9781250129321'

--- a/reviews/2018/ida.md
+++ b/reviews/2018/ida.md
@@ -3,7 +3,6 @@ book:
   author: Alison Evans
   cover:
     name: ida.jpg
-    size: 6942
     tint_color: '#307e8b'
   isbn10: '1760404381'
   isbn13: '9781760404383'

--- a/reviews/2018/liars-and-outliers.md
+++ b/reviews/2018/liars-and-outliers.md
@@ -3,7 +3,6 @@ book:
   author: Bruce Schneier
   cover:
     name: liars-and-outliers.jpg
-    size: 8297
     tint_color: '#9c161e'
   isbn10: '1118143302'
   isbn13: '9781118143308'

--- a/reviews/2018/looking-for-group.md
+++ b/reviews/2018/looking-for-group.md
@@ -3,7 +3,6 @@ book:
   author: Alexis Hall
   cover:
     name: looking-for-group.jpg
-    size: 9077
     tint_color: '#776038'
   isbn10: '1626494460'
   isbn13: '9781626494466'

--- a/reviews/2018/mallard-how-the-blue-streak-broke-the-world-speed-record.md
+++ b/reviews/2018/mallard-how-the-blue-streak-broke-the-world-speed-record.md
@@ -3,7 +3,6 @@ book:
   author: Don Hale
   cover:
     name: mallard-how-the-blue-streak-broke-the-world-speed-record.jpg
-    size: 21617
     tint_color: '#586c79'
   isbn10: '1854109391'
   isbn13: '9781854109392'

--- a/reviews/2018/norse-mythology.md
+++ b/reviews/2018/norse-mythology.md
@@ -3,7 +3,6 @@ book:
   author: Neil Gaiman
   cover:
     name: norse-mythology.jpg
-    size: 7327
     tint_color: '#756861'
   isbn10: '1408886804'
   isbn13: '9781408886809'

--- a/reviews/2018/places-i-stopped-on-the-way-home.md
+++ b/reviews/2018/places-i-stopped-on-the-way-home.md
@@ -3,7 +3,6 @@ book:
   author: Meg Fee
   cover:
     name: places-i-stopped-on-the-way-home.jpg
-    size: 6977
     tint_color: '#5f706d'
   isbn10: '1785783033'
   isbn13: '9781785783036'

--- a/reviews/2018/record-of-a-spaceborn-few.md
+++ b/reviews/2018/record-of-a-spaceborn-few.md
@@ -3,7 +3,6 @@ book:
   author: Becky Chambers
   cover:
     name: record-of-a-spaceborn-few.jpg
-    size: 9177
     tint_color: '#2c5094'
   isbn10: '1473647606'
   isbn13: '9781473647602'

--- a/reviews/2018/seven-ways-we-lie.md
+++ b/reviews/2018/seven-ways-we-lie.md
@@ -3,7 +3,6 @@ book:
   author: Riley Redgate
   cover:
     name: seven-ways-we-lie.jpg
-    size: 10373
     tint_color: '#767078'
   isbn10: '1419723480'
   isbn13: '9781419723483'

--- a/reviews/2018/the-art-of-lecturing.md
+++ b/reviews/2018/the-art-of-lecturing.md
@@ -3,7 +3,6 @@ book:
   author: Parham Aarabi
   cover:
     name: the-art-of-lecturing.jpg
-    size: 7944
     tint_color: '#011015'
   isbn10: '0521703522'
   isbn13: '9780521703529'

--- a/reviews/2018/the-butterfly-isles.md
+++ b/reviews/2018/the-butterfly-isles.md
@@ -3,7 +3,6 @@ book:
   author: Patrick Barkham
   cover:
     name: the-butterfly-isles.jpg
-    size: 9289
     tint_color: '#896229'
   isbn10: '1847083153'
   isbn13: '9781847083159'

--- a/reviews/2018/the-greatest-traitor-the-secret-lives-of-agent-george-blake.md
+++ b/reviews/2018/the-greatest-traitor-the-secret-lives-of-agent-george-blake.md
@@ -3,7 +3,6 @@ book:
   author: Roger Hermiston
   cover:
     name: the-greatest-traitor-the-secret-lives-of-agent-george-blake.jpg
-    size: 10010
     tint_color: '#7b6d63'
   isbn10: '1781310467'
   isbn13: '9781781310465'

--- a/reviews/2018/the-paper-menagerie-and-other-stories.md
+++ b/reviews/2018/the-paper-menagerie-and-other-stories.md
@@ -3,7 +3,6 @@ book:
   author: Ken Liu
   cover:
     name: the-paper-menagerie-and-other-stories.jpg
-    size: 5529
     tint_color: '#a45a3f'
   isbn10: 148142436X
   isbn13: '9781481424363'

--- a/reviews/2018/the-world-without-us.md
+++ b/reviews/2018/the-world-without-us.md
@@ -3,7 +3,6 @@ book:
   author: Alan Weisman
   cover:
     name: the-world-without-us.jpg
-    size: 12401
     tint_color: '#486469'
   isbn10: 0753513579
   isbn13: '9780753513576'

--- a/reviews/2018/wish-you-were-here-the-official-biography-of-douglas-adams.md
+++ b/reviews/2018/wish-you-were-here-the-official-biography-of-douglas-adams.md
@@ -3,7 +3,6 @@ book:
   author: Nick Webb
   cover:
     name: wish-you-were-here-the-official-biography-of-douglas-adams.jpg
-    size: 14562
     tint_color: '#826f55'
   isbn10: '0345476514'
   isbn13: '9780345476517'

--- a/reviews/2019/100-ways-to-improve-your-writing.md
+++ b/reviews/2019/100-ways-to-improve-your-writing.md
@@ -3,7 +3,6 @@ book:
   author: Gary Provost
   cover:
     name: 100-ways-to-improve-your-writing.jpg
-    size: 8914
     tint_color: '#2d588c'
   isbn10: '0451627210'
   isbn13: '9780451627216'

--- a/reviews/2019/1421-the-year-china-discovered-the-world.md
+++ b/reviews/2019/1421-the-year-china-discovered-the-world.md
@@ -3,7 +3,6 @@ book:
   author: Gavin Menzies
   cover:
     name: 1421-the-year-china-discovered-the-world.jpg
-    size: 9526
     tint_color: '#ce1125'
   isbn10: 0553815229
   isbn13: '9780553815221'

--- a/reviews/2019/a-brief-history-of-infinity.md
+++ b/reviews/2019/a-brief-history-of-infinity.md
@@ -3,7 +3,6 @@ book:
   author: Brian Clegg
   cover:
     name: a-brief-history-of-infinity.jpg
-    size: 5207
     tint_color: '#72695f'
   isbn10: '1841196509'
   isbn13: '9781841196503'

--- a/reviews/2019/a-laymans-guide-to-greek-heroes.md
+++ b/reviews/2019/a-laymans-guide-to-greek-heroes.md
@@ -3,7 +3,6 @@ book:
   author: Alan Carter
   cover:
     name: a-laymans-guide-to-greek-heroes.jpg
-    size: 12011
     tint_color: '#9d534b'
   isbn10: 960226487X
   isbn13: '9789602264874'

--- a/reviews/2019/abc-signalling-in-the-age-of-steam.md
+++ b/reviews/2019/abc-signalling-in-the-age-of-steam.md
@@ -3,7 +3,6 @@ book:
   author: Ian Allan
   cover:
     name: abc-signalling-in-the-age-of-steam.jpg
-    size: 24469
     tint_color: '#82736d'
   isbn10: '0711023506'
   isbn13: '9780711023505'

--- a/reviews/2019/ancillary-justice.md
+++ b/reviews/2019/ancillary-justice.md
@@ -3,7 +3,6 @@ book:
   author: Ann Leckie
   cover:
     name: ancillary-justice.jpg
-    size: 8077
     tint_color: '#b7162d'
   isbn10: 031624662X
   isbn13: '9780316246620'

--- a/reviews/2019/ancillary-mercy.md
+++ b/reviews/2019/ancillary-mercy.md
@@ -3,7 +3,6 @@ book:
   author: Ann Leckie
   cover:
     name: ancillary-mercy.jpg
-    size: 10214
     tint_color: '#981b1c'
   isbn10: '0356502422'
   isbn13: '9780356502427'

--- a/reviews/2019/ancillary-sword.md
+++ b/reviews/2019/ancillary-sword.md
@@ -3,7 +3,6 @@ book:
   author: Ann Leckie
   cover:
     name: ancillary-sword.jpg
-    size: 10047
     tint_color: '#dd312b'
   isbn10: '0316246654'
   isbn13: '9780316246651'

--- a/reviews/2019/antimatter.md
+++ b/reviews/2019/antimatter.md
@@ -3,7 +3,6 @@ book:
   author: Frank Close
   cover:
     name: antimatter.jpg
-    size: 9160
     tint_color: '#ae202b'
   isbn10: 0199550166
   isbn13: '9780199550166'

--- a/reviews/2019/as-you-wish-inconceivable-tales-from-the-making-of-the-princess-bride.md
+++ b/reviews/2019/as-you-wish-inconceivable-tales-from-the-making-of-the-princess-bride.md
@@ -3,7 +3,6 @@ book:
   author: Cary Elwes
   cover:
     name: as-you-wish-inconceivable-tales-from-the-making-of-the-princess-bride.jpg
-    size: 9909
     tint_color: '#7d7267'
   isbn10: '1501161903'
   isbn13: '9781501161902'

--- a/reviews/2019/atomic-accidents.md
+++ b/reviews/2019/atomic-accidents.md
@@ -3,7 +3,6 @@ book:
   author: James Mahaffey
   cover:
     name: atomic-accidents.jpg
-    size: 9882
     tint_color: '#48458c'
   isbn10: '1605986801'
   isbn13: '9781605986807'

--- a/reviews/2019/automating-inequality.md
+++ b/reviews/2019/automating-inequality.md
@@ -3,7 +3,6 @@ book:
   author: Virginia Eubanks
   cover:
     name: automating-inequality.jpg
-    size: 8575
     tint_color: '#6e655e'
   isbn10: '1250074312'
   isbn13: '9781250074317'

--- a/reviews/2019/beautiful-lego.md
+++ b/reviews/2019/beautiful-lego.md
@@ -3,7 +3,6 @@ book:
   author: Mike Doyle
   cover:
     name: beautiful-lego.jpg
-    size: 13701
     tint_color: '#000000'
   isbn10: '1593275080'
   isbn13: '9781593275082'

--- a/reviews/2019/beyond-burnout.md
+++ b/reviews/2019/beyond-burnout.md
@@ -3,7 +3,6 @@ book:
   author: Cary Cherniss
   cover:
     name: beyond-burnout.jpg
-    size: 9343
     tint_color: '#5c767e'
   isbn10: 0415912067
   isbn13: '9780415912068'

--- a/reviews/2019/bletchley-park-demystifying-the-bombe.md
+++ b/reviews/2019/bletchley-park-demystifying-the-bombe.md
@@ -3,7 +3,6 @@ book:
   author: Dermot Turing
   cover:
     name: bletchley-park-demystifying-the-bombe.jpg
-    size: 14311
     tint_color: '#a83a39'
   isbn13: '9781841655666'
   publication_year: 2015

--- a/reviews/2019/bletchley-park-home-of-the-codebreakers.md
+++ b/reviews/2019/bletchley-park-home-of-the-codebreakers.md
@@ -3,7 +3,6 @@ book:
   author: English Heritage
   cover:
     name: bletchley-park-home-of-the-codebreakers.jpg
-    size: 12834
     tint_color: '#96471f'
   isbn13: '9781841655451'
   publication_year: 2005

--- a/reviews/2019/carrying-the-fire.md
+++ b/reviews/2019/carrying-the-fire.md
@@ -3,7 +3,6 @@ book:
   author: Michael Collins
   cover:
     name: carrying-the-fire.jpg
-    size: 6602
     tint_color: '#b14547'
   isbn10: 0374531943
   isbn13: '9780374531942'

--- a/reviews/2019/chernobyl-history-of-a-tragedy.md
+++ b/reviews/2019/chernobyl-history-of-a-tragedy.md
@@ -3,7 +3,6 @@ book:
   author: Serhii Plokhy
   cover:
     name: chernobyl-history-of-a-tragedy.jpg
-    size: 10731
     tint_color: '#7b582b'
   isbn10: 0141988355
   isbn13: '9780141988351'

--- a/reviews/2019/electric-universe.md
+++ b/reviews/2019/electric-universe.md
@@ -3,7 +3,6 @@ book:
   author: David Bodanis
   cover:
     name: electric-universe.jpg
-    size: 11913
     tint_color: '#c8191d'
   isbn10: 0349117667
   isbn13: '9780349117669'

--- a/reviews/2019/from-here-to-eternity.md
+++ b/reviews/2019/from-here-to-eternity.md
@@ -3,7 +3,6 @@ book:
   author: Caitlin Doughty
   cover:
     name: from-here-to-eternity.jpg
-    size: 8467
     tint_color: '#000000'
   isbn10: 0393356280
   isbn13: '9780393356281'

--- a/reviews/2019/from-prejudice-to-pride.md
+++ b/reviews/2019/from-prejudice-to-pride.md
@@ -3,7 +3,6 @@ book:
   author: Amy Lame
   cover:
     name: from-prejudice-to-pride.jpg
-    size: 13016
     tint_color: '#b45743'
   isbn10: '1526301903'
   isbn13: '9781526301901'

--- a/reviews/2019/fun-home.md
+++ b/reviews/2019/fun-home.md
@@ -3,7 +3,6 @@ book:
   author: Alison Bechdel
   cover:
     name: fun-home.jpg
-    size: 8413
     tint_color: '#457569'
   isbn10: 0224080512
   isbn13: '9780224080514'

--- a/reviews/2019/gaming-the-vote.md
+++ b/reviews/2019/gaming-the-vote.md
@@ -3,7 +3,6 @@ book:
   author: William Poundstone
   cover:
     name: gaming-the-vote.jpg
-    size: 4946
     tint_color: '#594d4d'
   isbn10: 0809048930
   isbn13: '9780809048939'

--- a/reviews/2019/good-omens.md
+++ b/reviews/2019/good-omens.md
@@ -3,7 +3,6 @@ book:
   author: Terry Pratchett
   cover:
     name: good-omens.jpg
-    size: 9904
     tint_color: '#717170'
   isbn10: 0552171891
   isbn13: '9780552171892'

--- a/reviews/2019/grace-hopper-and-the-invention-of-the-information-age.md
+++ b/reviews/2019/grace-hopper-and-the-invention-of-the-information-age.md
@@ -3,7 +3,6 @@ book:
   author: Kurt W. Beyer
   cover:
     name: grace-hopper-and-the-invention-of-the-information-age.jpg
-    size: 6180
     tint_color: '#68686f'
   isbn10: '0262517264'
   isbn13: '9780262517263'

--- a/reviews/2019/h2o.md
+++ b/reviews/2019/h2o.md
@@ -3,7 +3,6 @@ book:
   author: Philip Ball
   cover:
     name: h2o.jpg
-    size: 11804
     tint_color: '#2b8093'
   isbn13: 978-0-7538-1092-7
   publication_year: 2000

--- a/reviews/2019/here-the-world-entire.md
+++ b/reviews/2019/here-the-world-entire.md
@@ -3,7 +3,6 @@ book:
   author: Anwen Kya Hayward
   cover:
     name: here-the-world-entire.jpg
-    size: 7009
     tint_color: '#50595b'
   isbn13: '9781326892005'
   publication_year: 2016

--- a/reviews/2019/history-of-the-world-in-500-railway-journeys.md
+++ b/reviews/2019/history-of-the-world-in-500-railway-journeys.md
@@ -3,7 +3,6 @@ book:
   author: Sarah Baxter
   cover:
     name: history-of-the-world-in-500-railway-journeys.jpg
-    size: 14702
     tint_color: '#6e4d31'
   isbn13: '9781781316788'
   publication_year: 2017

--- a/reviews/2019/how-to.md
+++ b/reviews/2019/how-to.md
@@ -3,7 +3,6 @@ book:
   author: Randall Munroe
   cover:
     name: how-to.jpg
-    size: 7686
     tint_color: '#19202a'
   isbn13: 978-1-4736-8035-7
   publication_year: 2019

--- a/reviews/2019/introduction-to-graph-theory.md
+++ b/reviews/2019/introduction-to-graph-theory.md
@@ -3,7 +3,6 @@ book:
   author: Robin J. Wilson
   cover:
     name: introduction-to-graph-theory.jpg
-    size: 8134
     tint_color: '#332d5d'
   isbn10: 027372889X
   isbn13: '9780273728894'

--- a/reviews/2019/laymans-guide-to-the-greek-gods.md
+++ b/reviews/2019/laymans-guide-to-the-greek-gods.md
@@ -3,7 +3,6 @@ book:
   author: Alan & Maureen Carter
   cover:
     name: laymans-guide-to-the-greek-gods.jpg
-    size: 11789
     tint_color: '#915e5b'
   isbn10: '9602264888'
   isbn13: '9789602264881'

--- a/reviews/2019/lego-architecture-the-visual-guide.md
+++ b/reviews/2019/lego-architecture-the-visual-guide.md
@@ -3,7 +3,6 @@ book:
   author: Philip Wilkinson
   cover:
     name: lego-architecture-the-visual-guide.jpg
-    size: 9268
     tint_color: '#181818'
   isbn10: '1409355721'
   isbn13: '9781409355724'

--- a/reviews/2019/lewis-carroll-in-numberland-his-fantastical-mathematical-logical-life.md
+++ b/reviews/2019/lewis-carroll-in-numberland-his-fantastical-mathematical-logical-life.md
@@ -3,7 +3,6 @@ book:
   author: Robin J. Wilson
   cover:
     name: lewis-carroll-in-numberland-his-fantastical-mathematical-logical-life.jpg
-    size: 9480
     tint_color: '#767163'
   isbn10: 0141016108
   isbn13: '9780141016108'

--- a/reviews/2019/locomotives-of-the-great-western-railway-jarrold-railway-series-1.md
+++ b/reviews/2019/locomotives-of-the-great-western-railway-jarrold-railway-series-1.md
@@ -3,7 +3,6 @@ book:
   author: Alan Bloom
   cover:
     name: locomotives-of-the-great-western-railway-jarrold-railway-series-1.jpg
-    size: 9627
     tint_color: '#a75f5e'
   isbn10: 0853068372
   isbn13: '9780853068372'

--- a/reviews/2019/london-underground-by-design.md
+++ b/reviews/2019/london-underground-by-design.md
@@ -3,7 +3,6 @@ book:
   author: Mark Ovenden
   cover:
     name: london-underground-by-design.jpg
-    size: 7813
     tint_color: '#746730'
   isbn10: '1846144175'
   isbn13: '9781846144172'

--- a/reviews/2019/lorenz.md
+++ b/reviews/2019/lorenz.md
@@ -3,7 +3,6 @@ book:
   author: Jerry Roberts
   cover:
     name: lorenz.jpg
-    size: 10972
     tint_color: '#b05d34'
   isbn10: 0750978856
   isbn13: '9780750978859'

--- a/reviews/2019/messages-from-the-sea.md
+++ b/reviews/2019/messages-from-the-sea.md
@@ -3,7 +3,6 @@ book:
   author: Paul Brown
   cover:
     name: messages-from-the-sea.jpg
-    size: 10749
     tint_color: '#3c757a'
   isbn10: 0995541213
   isbn13: '9780995541214'

--- a/reviews/2019/mismatch.md
+++ b/reviews/2019/mismatch.md
@@ -3,7 +3,6 @@ book:
   author: Kat Holmes
   cover:
     name: mismatch.jpg
-    size: 6104
     tint_color: '#6f6f6f'
   isbn10: 0262038889
   isbn13: '9780262038881'

--- a/reviews/2019/nineteen-eighty-four.md
+++ b/reviews/2019/nineteen-eighty-four.md
@@ -3,7 +3,6 @@ book:
   author: George Orwell
   cover:
     name: nineteen-eighty-four.jpg
-    size: 9468
     tint_color: '#000000'
   isbn10: 0140009728
   isbn13: '9780140009729'

--- a/reviews/2019/oh-no.md
+++ b/reviews/2019/oh-no.md
@@ -3,7 +3,6 @@ book:
   author: Alex Norris
   cover:
     name: oh-no.jpg
-    size: 6214
     tint_color: '#586f7c'
   isbn10: '1449492533'
   isbn13: '9781449492533'

--- a/reviews/2019/platos-podcasts.md
+++ b/reviews/2019/platos-podcasts.md
@@ -3,7 +3,6 @@ book:
   author: Mark Vernon
   cover:
     name: platos-podcasts.jpg
-    size: 10071
     tint_color: '#c24d48'
   isbn13: 978-1-85168-706-0
   publication_year: 2009

--- a/reviews/2019/provenance.md
+++ b/reviews/2019/provenance.md
@@ -3,7 +3,6 @@ book:
   author: Ann Leckie
   cover:
     name: provenance.jpg
-    size: 10082
     tint_color: '#ab2b33'
   isbn10: 0356506983
   isbn13: '9780356506982'

--- a/reviews/2019/seashaken-houses.md
+++ b/reviews/2019/seashaken-houses.md
@@ -3,7 +3,6 @@ book:
   author: Tom Nancollas
   cover:
     name: seashaken-houses.jpg
-    size: 7285
     tint_color: '#5b6c74'
   isbn10: '1846149371'
   isbn13: '9781846149375'

--- a/reviews/2019/smoke-gets-in-your-eyes.md
+++ b/reviews/2019/smoke-gets-in-your-eyes.md
@@ -3,7 +3,6 @@ book:
   author: Caitlin Doughty
   cover:
     name: smoke-gets-in-your-eyes.jpg
-    size: 8196
     tint_color: '#6d675e'
   isbn10: '1782111050'
   isbn13: '9781782111054'

--- a/reviews/2019/strange-planet.md
+++ b/reviews/2019/strange-planet.md
@@ -3,7 +3,6 @@ book:
   author: Nathan Pyle
   cover:
     name: strange-planet.jpg
-    size: 8243
     tint_color: '#82404e'
   isbn13: 978-1-4722-6904-1
   publication_year: 2019

--- a/reviews/2019/the-ancient-greek-computer-from-rhodes.md
+++ b/reviews/2019/the-ancient-greek-computer-from-rhodes.md
@@ -3,7 +3,6 @@ book:
   author: V.J. Kean
   cover:
     name: the-ancient-greek-computer-from-rhodes.jpg
-    size: 8399
     tint_color: '#6e6d5a'
   isbn10: '9602262273'
   isbn13: '9789602262276'

--- a/reviews/2019/the-art-of-betrayal.md
+++ b/reviews/2019/the-art-of-betrayal.md
@@ -3,7 +3,6 @@ book:
   author: Gordon Corera
   cover:
     name: the-art-of-betrayal.jpg
-    size: 7788
     tint_color: '#b12b35'
   isbn10: 0297860992
   isbn13: '9780297860990'

--- a/reviews/2019/the-artist-and-the-mathematician.md
+++ b/reviews/2019/the-artist-and-the-mathematician.md
@@ -3,7 +3,6 @@ book:
   author: Amir D. Aczel
   cover:
     name: the-artist-and-the-mathematician.jpg
-    size: 10891
     tint_color: '#6d7079'
   isbn10: '1843440393'
   isbn13: '9781843440390'

--- a/reviews/2019/the-box-how-the-shipping-container-made-the-world-smaller-and-the-world-economy-bigger.md
+++ b/reviews/2019/the-box-how-the-shipping-container-made-the-world-smaller-and-the-world-economy-bigger.md
@@ -3,7 +3,6 @@ book:
   author: Marc Levinson
   cover:
     name: the-box-how-the-shipping-container-made-the-world-smaller-and-the-world-economy-bigger.jpg
-    size: 12102
     tint_color: '#566293'
   isbn10: 0691170819
   isbn13: '9780691170817'

--- a/reviews/2019/the-design-of-everyday-things.md
+++ b/reviews/2019/the-design-of-everyday-things.md
@@ -3,7 +3,6 @@ book:
   author: Donald A. Norman
   cover:
     name: the-design-of-everyday-things.jpg
-    size: 18653
     tint_color: '#456b5c'
   isbn10: '0262525674'
   isbn13: '9780262525671'

--- a/reviews/2019/the-enchanted-castle.md
+++ b/reviews/2019/the-enchanted-castle.md
@@ -3,7 +3,6 @@ book:
   author: E. Nesbit
   cover:
     name: the-enchanted-castle.jpg
-    size: 7929
     tint_color: '#cb3828'
   isbn10: 0140367438
   isbn13: '9780140367430'

--- a/reviews/2019/the-life-changing-magic-of-tidying-up.md
+++ b/reviews/2019/the-life-changing-magic-of-tidying-up.md
@@ -3,7 +3,6 @@ book:
   author: Marie Kondō
   cover:
     name: the-life-changing-magic-of-tidying-up.jpg
-    size: 6809
     tint_color: '#bd1c24'
   isbn10: '1607747308'
   isbn13: '9781607747307'

--- a/reviews/2019/the-maths-gene.md
+++ b/reviews/2019/the-maths-gene.md
@@ -3,7 +3,6 @@ book:
   author: Keith J. Devlin
   cover:
     name: the-maths-gene.jpg
-    size: 10249
     tint_color: '#974450'
   isbn10: 0297645714
   isbn13: '9780297645719'

--- a/reviews/2019/the-meaning-of-it-all.md
+++ b/reviews/2019/the-meaning-of-it-all.md
@@ -3,7 +3,6 @@ book:
   author: Richard P. Feynman
   cover:
     name: the-meaning-of-it-all.jpg
-    size: 10853
     tint_color: '#b74946'
   isbn10: '0141031441'
   isbn13: '9780141031446'

--- a/reviews/2019/the-phoenix-and-the-carpet.md
+++ b/reviews/2019/the-phoenix-and-the-carpet.md
@@ -3,7 +3,6 @@ book:
   author: E. Nesbit
   cover:
     name: the-phoenix-and-the-carpet.jpg
-    size: 7860
     tint_color: '#d14434'
   isbn10: 014036739X
   isbn13: '9780140367393'

--- a/reviews/2019/the-princess-bride.md
+++ b/reviews/2019/the-princess-bride.md
@@ -3,7 +3,6 @@ book:
   author: William Goldman
   cover:
     name: the-princess-bride.jpg
-    size: 13258
     tint_color: '#616363'
   isbn10: 0747545189
   isbn13: '9780747545187'

--- a/reviews/2019/the-railway-adventures.md
+++ b/reviews/2019/the-railway-adventures.md
@@ -3,7 +3,6 @@ book:
   author: Geoff Marshall, Vicki Pipe
   cover:
     name: the-railway-adventures.jpg
-    size: 6421
     tint_color: '#135c96'
   isbn10: '1910463876'
   isbn13: '9781910463871'

--- a/reviews/2019/the-universe-next-door.md
+++ b/reviews/2019/the-universe-next-door.md
@@ -3,7 +3,6 @@ book:
   author: Marcus Chown
   cover:
     name: the-universe-next-door.jpg
-    size: 5744
     tint_color: '#000000'
   isbn10: 0747235287
   isbn13: '9780747235286'

--- a/reviews/2019/the-unofficial-lego-technic-builders-guide.md
+++ b/reviews/2019/the-unofficial-lego-technic-builders-guide.md
@@ -3,7 +3,6 @@ book:
   author: Paweł "Sariel" Kmieć
   cover:
     name: the-unofficial-lego-technic-builders-guide.jpg
-    size: 8838
     tint_color: '#2772b7'
   isbn10: '1593274343'
   isbn13: '9781593274344'

--- a/reviews/2019/the-void.md
+++ b/reviews/2019/the-void.md
@@ -3,7 +3,6 @@ book:
   author: Frank Close
   cover:
     name: the-void.jpg
-    size: 4468
     tint_color: '#c41018'
   isbn10: 0199225907
   isbn13: '9780199225903'

--- a/reviews/2019/to-be-taught-if-fortunate.md
+++ b/reviews/2019/to-be-taught-if-fortunate.md
@@ -3,7 +3,6 @@ book:
   author: Becky Chambers
   cover:
     name: to-be-taught-if-fortunate.jpg
-    size: 8013
     tint_color: '#c8481a'
   isbn10: '1473697166'
   isbn13: '9781473697164'

--- a/reviews/2019/volks-electric-railway-a-visitors-guide.md
+++ b/reviews/2019/volks-electric-railway-a-visitors-guide.md
@@ -3,7 +3,6 @@ book:
   author: Peter Walker
   cover:
     name: volks-electric-railway-a-visitors-guide.jpg
-    size: 10142
     tint_color: '#7d654b'
   isbn13: '9780957589858'
   publication_year: 2018

--- a/reviews/2019/volks-railways-brighton-an-illustrated-history.md
+++ b/reviews/2019/volks-railways-brighton-an-illustrated-history.md
@@ -3,7 +3,6 @@ book:
   author: Alan A. Jackson
   cover:
     name: volks-railways-brighton-an-illustrated-history.jpg
-    size: 10016
     tint_color: '#965535'
   isbn10: '1871980186'
   isbn13: '9781871980189'

--- a/reviews/2019/why-buildings-stand-up.md
+++ b/reviews/2019/why-buildings-stand-up.md
@@ -3,7 +3,6 @@ book:
   author: Mario Salvadori
   cover:
     name: why-buildings-stand-up.jpg
-    size: 8633
     tint_color: '#764145'
   isbn10: 0393306763
   isbn13: '9780393306767'

--- a/reviews/2019/write-to-the-point.md
+++ b/reviews/2019/write-to-the-point.md
@@ -3,7 +3,6 @@ book:
   author: Sam Leith
   cover:
     name: write-to-the-point.jpg
-    size: 7578
     tint_color: '#3a3839'
   isbn10: '1781254761'
   isbn13: '9781781254769'

--- a/reviews/2019/yes-you-are-trans-enough.md
+++ b/reviews/2019/yes-you-are-trans-enough.md
@@ -3,7 +3,6 @@ book:
   author: Mia Violet
   cover:
     name: yes-you-are-trans-enough.jpg
-    size: 9683
     tint_color: '#427590'
   isbn10: '1785923153'
   isbn13: '9781785923159'

--- a/reviews/2020/a-spellers-companion.md
+++ b/reviews/2020/a-spellers-companion.md
@@ -3,7 +3,6 @@ book:
   author: Brown and Brown
   cover:
     name: a-spellers-companion.jpg
-    size: 6803
     tint_color: '#42342f'
   isbn13: '9781904874041'
   publication_year: 1987

--- a/reviews/2020/airman.md
+++ b/reviews/2020/airman.md
@@ -3,7 +3,6 @@ book:
   author: Eoin Colfer
   cover:
     name: airman.jpg
-    size: 11508
     tint_color: '#276560'
   isbn13: '9780141383354'
   publication_year: 2008

--- a/reviews/2020/all-systems-red.md
+++ b/reviews/2020/all-systems-red.md
@@ -3,7 +3,6 @@ book:
   author: Martha Wells
   cover:
     name: all-systems-red.jpg
-    size: 6908
     tint_color: '#752d1e'
   isbn13: '9780765397522'
   publication_year: 2017

--- a/reviews/2020/am-i-overthinking-this.md
+++ b/reviews/2020/am-i-overthinking-this.md
@@ -3,7 +3,6 @@ book:
   author: Michelle Rial
   cover:
     name: am-i-overthinking-this.jpg
-    size: 9423
     tint_color: '#6d6b93'
   isbn13: 978-1-4521-7586-7
   publication_year: 2019

--- a/reviews/2020/an-atlas-of-extinct-countries.md
+++ b/reviews/2020/an-atlas-of-extinct-countries.md
@@ -3,7 +3,6 @@ book:
   author: Gideon Defoe
   cover:
     name: an-atlas-of-extinct-countries.jpg
-    size: 15007
     tint_color: '#0c7e72'
   publication_year: 2020
   title: An Atlas of Extinct Countries

--- a/reviews/2020/artificial-condition.md
+++ b/reviews/2020/artificial-condition.md
@@ -3,7 +3,6 @@ book:
   author: Martha Wells
   cover:
     name: artificial-condition-murderbot-2.jpg
-    size: 7718
     tint_color: '#966b45'
   isbn13: '9781250186935'
   publication_year: 2018

--- a/reviews/2020/atomic.md
+++ b/reviews/2020/atomic.md
@@ -3,7 +3,6 @@ book:
   author: Jim Baggott
   cover:
     name: atomic.jpg
-    size: 11826
     tint_color: '#4f688e'
   publication_year: 2015
   title: Atomic

--- a/reviews/2020/behind-the-scenes-at-scrapheap-challenge.md
+++ b/reviews/2020/behind-the-scenes-at-scrapheap-challenge.md
@@ -3,7 +3,6 @@ book:
   author: Robert Llewellyn
   cover:
     name: behind-the-scenes-at-scrapheap-challenge.jpg
-    size: 11183
     tint_color: '#424f83'
   isbn10: 0752219995
   isbn13: '9780752219998'

--- a/reviews/2020/bite-size-bash.md
+++ b/reviews/2020/bite-size-bash.md
@@ -3,7 +3,6 @@ book:
   author: Julia Evans
   cover:
     name: bite-size-bash.jpg
-    size: 51146
     tint_color: '#856155'
   publication_year: 2020
   title: Bite Size Bash

--- a/reviews/2020/codebreakers-the-inside-story-of-bletchley-park.md
+++ b/reviews/2020/codebreakers-the-inside-story-of-bletchley-park.md
@@ -3,7 +3,6 @@ book:
   author: F.H. Hinsley and Alan Tripp
   cover:
     name: codebreakers-the-inside-story-of-bletchley-park.jpg
-    size: 7926
     tint_color: '#bb0a0a'
   isbn13: '9780198203278'
   publication_year: 1993

--- a/reviews/2020/creative-selection.md
+++ b/reviews/2020/creative-selection.md
@@ -3,7 +3,6 @@ book:
   author: Ken Kocienda
   cover:
     name: creative-selection.png
-    size: 7450
     tint_color: '#0772b8'
   publication_year: 2018
   title: Creative Selection

--- a/reviews/2020/engineering-a-safer-world.md
+++ b/reviews/2020/engineering-a-safer-world.md
@@ -3,7 +3,6 @@ book:
   author: Nancy G. Leveson
   cover:
     name: engineering-a-safer-world.jpg
-    size: 5492
     tint_color: '#000000'
   publication_year: 2012
   title: Engineering a Safer World

--- a/reviews/2020/exit-strategy.md
+++ b/reviews/2020/exit-strategy.md
@@ -3,7 +3,6 @@ book:
   author: Martha Wells
   cover:
     name: exit-strategy.jpg
-    size: 9802
     tint_color: '#797474'
   isbn13: '9781250185454'
   publication_year: 2018

--- a/reviews/2020/gchq.md
+++ b/reviews/2020/gchq.md
@@ -3,7 +3,6 @@ book:
   author: Richard Aldrich
   cover:
     name: gchq.jpg
-    size: 10742
     tint_color: '#646357'
   isbn13: '9780007278473'
   publication_year: 2010

--- a/reviews/2020/how-to-be-a-good-motorist.md
+++ b/reviews/2020/how-to-be-a-good-motorist.md
@@ -3,7 +3,6 @@ book:
   author: the Bodleian Library
   cover:
     name: how-to-be-a-good-motorist.jpg
-    size: 158891
     tint_color: '#9c1d26'
   isbn13: '9781851240807'
   publication_year: 2013

--- a/reviews/2020/ibm-and-the-holocaust.md
+++ b/reviews/2020/ibm-and-the-holocaust.md
@@ -3,7 +3,6 @@ book:
   author: Edwin Black
   cover:
     name: ibm-and-the-holocaust.jpg
-    size: 41340
     tint_color: '#827469'
   isbn10: 0751531995
   isbn13: '9780751531992'

--- a/reviews/2020/intimate-friendships.md
+++ b/reviews/2020/intimate-friendships.md
@@ -3,7 +3,6 @@ book:
   author: James W. Ramey
   cover:
     name: intimate-friendships.jpg
-    size: 6561
     tint_color: '#862a20'
   isbn10: 0134768957
   isbn13: '9780134768953'

--- a/reviews/2020/montmorency.md
+++ b/reviews/2020/montmorency.md
@@ -3,7 +3,6 @@ book:
   author: Eleanor Updale
   cover:
     name: montmorency.jpg
-    size: 7100
     tint_color: '#72577c'
   isbn10: 0439978408
   isbn13: '9780439978408'

--- a/reviews/2020/nets-puzzles-and-postmen.md
+++ b/reviews/2020/nets-puzzles-and-postmen.md
@@ -3,7 +3,6 @@ book:
   author: Peter M Higgins
   cover:
     name: nets-puzzles-and-postmen.jpg
-    size: 5323
     tint_color: '#c05442'
   isbn13: 978-0-19-921842-4
   publication_year: 2007

--- a/reviews/2020/notes-from-small-planets.md
+++ b/reviews/2020/notes-from-small-planets.md
@@ -3,7 +3,6 @@ book:
   author: Nate Crowley
   cover:
     name: notes-from-small-planets.jpg
-    size: 103272
     tint_color: '#796787'
   isbn13: '9780008306861'
   publication_year: 2020

--- a/reviews/2020/on-the-beach.md
+++ b/reviews/2020/on-the-beach.md
@@ -3,7 +3,6 @@ book:
   author: Nevil Shute
   cover:
     name: on-the-beach.jpg
-    size: 6412
     tint_color: '#991b1e'
   isbn13: 978-1-55199-862-6
   publication_year: 1957

--- a/reviews/2020/quicksilver-ultraviolet-2.md
+++ b/reviews/2020/quicksilver-ultraviolet-2.md
@@ -3,7 +3,6 @@ book:
   author: R.J. Anderson
   cover:
     name: quicksilver-ultraviolet-2.jpg
-    size: 9786
     tint_color: '#667794'
   isbn10: '1408316285'
   isbn13: '9781408316283'

--- a/reviews/2020/rogue-protocol.md
+++ b/reviews/2020/rogue-protocol.md
@@ -3,7 +3,6 @@ book:
   author: Martha Wells
   cover:
     name: rogue-protocol.jpg
-    size: 8107
     tint_color: '#686d72'
   isbn13: '9781250185433'
   publication_year: 2018

--- a/reviews/2020/small-robots.md
+++ b/reviews/2020/small-robots.md
@@ -3,7 +3,6 @@ book:
   author: Thomas Heasman-Hunt
   cover:
     name: small-robots.jpg
-    size: 15159
     tint_color: '#68565e'
   isbn13: '9781783528226'
   publication_year: 2019

--- a/reviews/2020/the-chinese-typewriter-a-history.md
+++ b/reviews/2020/the-chinese-typewriter-a-history.md
@@ -3,7 +3,6 @@ book:
   author: Thomas S. Mullaney
   cover:
     name: the-chinese-typewriter-a-history.jpg
-    size: 175873
     tint_color: '#bd292f'
   publication_year: 2017
   title: 'The Chinese Typewriter: A History'

--- a/reviews/2020/the-city-the-city.md
+++ b/reviews/2020/the-city-the-city.md
@@ -3,7 +3,6 @@ book:
   author: China Miéville
   cover:
     name: the-city-the-city.jpg
-    size: 9125
     tint_color: '#3c4387'
   isbn13: '9781509870585'
   publication_year: 2009

--- a/reviews/2020/the-day-of-the-triffids.md
+++ b/reviews/2020/the-day-of-the-triffids.md
@@ -3,7 +3,6 @@ book:
   author: John Wyndham
   cover:
     name: the-day-of-the-triffids.jpg
-    size: 6995
     tint_color: '#715e36'
   isbn10: 0140009930
   publication_year: 1951

--- a/reviews/2020/the-elements-of-style.md
+++ b/reviews/2020/the-elements-of-style.md
@@ -3,7 +3,6 @@ book:
   author: William Strunk Jr.
   cover:
     name: the-elements-of-style.jpg
-    size: 9564
     tint_color: '#497c90'
   isbn13: '9780205309023'
   publication_year: 1918

--- a/reviews/2020/the-gate-of-angels.md
+++ b/reviews/2020/the-gate-of-angels.md
@@ -3,7 +3,6 @@ book:
   author: Penelope Fitzgerald
   cover:
     name: the-gate-of-angels.jpg
-    size: 7449
     tint_color: '#81593a'
   isbn10: '0002235277'
   isbn13: '9780002235273'

--- a/reviews/2020/the-lonely-city.md
+++ b/reviews/2020/the-lonely-city.md
@@ -3,7 +3,6 @@ book:
   author: Olivia Laing
   cover:
     name: the-lonely-city.jpg
-    size: 8152
     tint_color: '#bc4035'
   isbn13: 9781782111245
   publication_year: 2016

--- a/reviews/2020/the-magazine-the-book.md
+++ b/reviews/2020/the-magazine-the-book.md
@@ -3,7 +3,6 @@ book:
   author: Glenn Fleishman
   cover:
     name: the-magazine-the-book.jpg
-    size: 12480
     tint_color: '#677b54'
   isbn10: 0991439902
   isbn13: '9780991439904'

--- a/reviews/2020/the-night-circus.md
+++ b/reviews/2020/the-night-circus.md
@@ -3,7 +3,6 @@ book:
   author: Erin Morgenstern
   cover:
     name: the-night-circus.jpg
-    size: 8850
     tint_color: '#050004'
   publication_year: 2011
   title: The Night Circus

--- a/reviews/2020/the-ones-who-walk-away-from-omelas.md
+++ b/reviews/2020/the-ones-who-walk-away-from-omelas.md
@@ -3,7 +3,6 @@ book:
   author: Ursula K. Le Guin
   cover:
     name: the-ones-who-walk-away-from-omelas.jpg
-    size: 11804
     tint_color: '#73615f'
   publication_year: 1973
   title: The Ones Who Walk Away From Omelas

--- a/reviews/2020/the-read-aloud-cloud.md
+++ b/reviews/2020/the-read-aloud-cloud.md
@@ -3,7 +3,6 @@ book:
   author: Forrest Brazeal
   cover:
     name: the-read-aloud-cloud.png
-    size: 168769
     tint_color: '#5d686d'
   isbn13: '9781119677628'
   publication_year: 2020

--- a/reviews/2020/the-rust-programming-language.md
+++ b/reviews/2020/the-rust-programming-language.md
@@ -3,7 +3,6 @@ book:
   author: Steve Klabnik and Carol Nichols
   cover:
     name: the-rust-programming-language.jpg
-    size: 130296
     tint_color: '#b64725'
   publication_year: 2018
   title: The Rust Programming Language

--- a/reviews/2020/the-secret-listeners-2019.md
+++ b/reviews/2020/the-secret-listeners-2019.md
@@ -3,7 +3,6 @@ book:
   author: Sinclair McKay
   cover:
     name: the-secret-listeners.jpg
-    size: 21219
     tint_color: '#c14d4b'
   isbn13: '9781845137632'
   publication_year: 2012

--- a/reviews/2020/the-starless-sea.md
+++ b/reviews/2020/the-starless-sea.md
@@ -3,7 +3,6 @@ book:
   author: Erin Morgenstern
   cover:
     name: the-starless-sea.jpg
-    size: 171084
     tint_color: '#106986'
   publication_year: 2019
   title: The Starless Sea

--- a/reviews/2020/the-story-of-brexit-a-ladybird-book.md
+++ b/reviews/2020/the-story-of-brexit-a-ladybird-book.md
@@ -3,7 +3,6 @@ book:
   author: Ladybird Books
   cover:
     name: the-story-of-brexit-a-ladybird-book.jpg
-    size: 47313
     tint_color: '#795a44'
   isbn13: '9780241386569'
   publication_year: 2018

--- a/reviews/2020/the-trains-now-departed.md
+++ b/reviews/2020/the-trains-now-departed.md
@@ -3,7 +3,6 @@ book:
   author: Michael Williams
   cover:
     name: the-trains-now-departed.jpg
-    size: 46771
     tint_color: '#c03038'
   isbn13: '9780099590583'
   publication_year: 2015

--- a/reviews/2020/the-wandering-wombles.md
+++ b/reviews/2020/the-wandering-wombles.md
@@ -3,7 +3,6 @@ book:
   author: Elisabeth Beresford
   cover:
     name: the-wandering-wombles.jpg
-    size: 10825
     tint_color: '#d23675'
   publication_year: 1970
   title: The Wandering Wombles

--- a/reviews/2020/trans-britain.md
+++ b/reviews/2020/trans-britain.md
@@ -3,7 +3,6 @@ book:
   author: Christine Burns
   cover:
     name: trans-britain.jpg
-    size: 21455
     tint_color: '#955594'
   isbn13: 978-1-78352-470-9
   publication_year: 2018

--- a/reviews/2020/trans-like-me.md
+++ b/reviews/2020/trans-like-me.md
@@ -3,7 +3,6 @@ book:
   author: C. N. Lester
   cover:
     name: trans-like-me.jpg
-    size: 7818
     tint_color: '#d92839'
   cover_desc: 'The words “trans like me” in lowercased, large letters, set on a slightly
     off-white background. The words “trans” and “me” are in red; the word “like” is

--- a/reviews/2020/ultraviolet-ultraviolet-1.md
+++ b/reviews/2020/ultraviolet-ultraviolet-1.md
@@ -3,7 +3,6 @@ book:
   author: R.J. Anderson
   cover:
     name: ultraviolet-ultraviolet-1.jpg
-    size: 11657
     tint_color: '#6b637e'
   isbn10: '1408312751'
   isbn13: '9781408312759'

--- a/reviews/2020/welwyn-railways.md
+++ b/reviews/2020/welwyn-railways.md
@@ -3,7 +3,6 @@ book:
   author: The Revd. Tim W. Gladwin, Peter W. Neville, Douglas E. White
   cover:
     name: welwyn-railways.jpg
-    size: 35294
     tint_color: '#736954'
   isbn10: 0948555041
   isbn13: '9780948555046'

--- a/reviews/2020/why-buildings-fall-down.md
+++ b/reviews/2020/why-buildings-fall-down.md
@@ -3,7 +3,6 @@ book:
   author: Matthys Levy, Mario Salvadori
   cover:
     name: why-buildings-fall-down.jpg
-    size: 14896
     tint_color: '#716a81'
   cover_desc: 'White cover, with the words “Why Buildings Fall Down” in blue. Below
     the title is a picture pof three buildings: (L-R) a multi-storey white building

--- a/reviews/2020/why-im-no-longer-talking-to-white-people-about-race.md
+++ b/reviews/2020/why-im-no-longer-talking-to-white-people-about-race.md
@@ -3,7 +3,6 @@ book:
   author: Reni Eddo-Lodge
   cover:
     name: why-im-no-longer-talking-to-white-people-about-race.jpg
-    size: 8563
     tint_color: '#696969'
   isbn13: '9781408870587'
   publication_year: 2017

--- a/reviews/2020/yellow-trains.md
+++ b/reviews/2020/yellow-trains.md
@@ -3,7 +3,6 @@ book:
   author: Andrew Royle
   cover:
     name: yellow-trains.png
-    size: 122581
     tint_color: '#736c43'
   isbn13: '9781910809587'
   publication_year: 2019

--- a/reviews/2021/a-big-ship-at-the-edge-of-the-universe.md
+++ b/reviews/2021/a-big-ship-at-the-edge-of-the-universe.md
@@ -4,7 +4,6 @@ book:
   narrator: Charlotte Blacklock
   cover:
     name: a-big-ship-at-the-edge-of-the-universe.jpeg
-    size: 488912
     tint_color: "#090a1d"
   publication_year: 2018
   title: A Big Ship at the Edge of the Universe

--- a/reviews/2021/abandoned-america.md
+++ b/reviews/2021/abandoned-america.md
@@ -3,7 +3,6 @@ book:
   author: Matthew Christopher
   cover:
     name: abandoned-america-the-age-of-consequences.jpg
-    size: 9584
     tint_color: '#726c66'
   publication_year: 2014
   title: Abandoned America

--- a/reviews/2021/atomic-habits.md
+++ b/reviews/2021/atomic-habits.md
@@ -3,7 +3,6 @@ book:
   author: James Clear
   cover:
     name: atomic-habits.jpg
-    size: 8657
     tint_color: '#a8663e'
   publication_year: 2018
   title: Atomic Habits

--- a/reviews/2021/black-and-british.md
+++ b/reviews/2021/black-and-british.md
@@ -3,7 +3,6 @@ book:
   author: David Olusoga
   cover:
     name: black-and-british.jpg
-    size: 69142
     tint_color: '#166e7e'
   narrator: Ben Onwukwe
   publication_year: 2016

--- a/reviews/2021/bure-valley-recollections.md
+++ b/reviews/2021/bure-valley-recollections.md
@@ -3,7 +3,6 @@ book:
   author: Gerry Balding & Andrew Barnes
   cover:
     name: bure-valley-railway-recollections.jpg
-    size: 56992
     tint_color: '#c21b1d'
   isbn13: '9781857945805'
   publication_year: 2018

--- a/reviews/2021/captain-corellis-mandolin.md
+++ b/reviews/2021/captain-corellis-mandolin.md
@@ -3,7 +3,6 @@ book:
   author: Louis de Bernières
   cover:
     name: captain-corellis-mandolin.jpg
-    size: 15351
     tint_color: '#270b60'
   isbn10: 0749397543
   isbn13: '9780749397548'

--- a/reviews/2021/codebreaker-the-untold-story-of-richard-hayes.md
+++ b/reviews/2021/codebreaker-the-untold-story-of-richard-hayes.md
@@ -3,7 +3,6 @@ book:
   author: Marc McMenamin
   cover:
     name: codebreaker-the-untold-story-of-richard-hayes.jpg
-    size: 52532
     tint_color: '#737270'
   narrator: Aidan Kelly
   publication_year: 2020

--- a/reviews/2021/colossus-bletchley-parks-greatest-secret.md
+++ b/reviews/2021/colossus-bletchley-parks-greatest-secret.md
@@ -3,7 +3,6 @@ book:
   author: Paul Gannon
   cover:
     name: colossus-bletchley-parks-greatest-secret.jpg
-    size: 14621
     tint_color: '#cf2c4e'
   publication_year: 2007
   title: 'Colossus: Bletchley Park''s Greatest Secret'

--- a/reviews/2021/comet-in-moominland.md
+++ b/reviews/2021/comet-in-moominland.md
@@ -3,7 +3,6 @@ book:
   author: Tove Jansson
   cover:
     name: comet-in-moominland.jpg
-    size: 54777
     tint_color: '#2d5980'
   isbn13: '9781908745651'
   publication_year: 1946

--- a/reviews/2021/cosmogramma.md
+++ b/reviews/2021/cosmogramma.md
@@ -3,7 +3,6 @@ book:
   author: Courttia Newland
   cover:
     name: cosmogramma.jpg
-    size: 936468
     tint_color: '#c75027'
   publication_year: 2021
   title: Cosmogramma

--- a/reviews/2021/dick-whittington-and-his-cat.md
+++ b/reviews/2021/dick-whittington-and-his-cat.md
@@ -5,7 +5,6 @@ book:
   illustrator: Eric Winter
   cover:
     name: dick-whittington-and-his-cat.jpg
-    size: 41713
     tint_color: "#b49c3c"
   publication_year: 1966
   title: Dick Whittington and his cat

--- a/reviews/2021/digging-for-words.md
+++ b/reviews/2021/digging-for-words.md
@@ -3,7 +3,6 @@ book:
   author: Angela Burke Kunkel
   cover:
     name: digging-for-words.jpg
-    size: 157166
     tint_color: '#617684'
   illustrator: Paola Escobar
   isbn13: '9781984892638'

--- a/reviews/2021/disability-visibility.md
+++ b/reviews/2021/disability-visibility.md
@@ -2,7 +2,6 @@
 book:
   cover:
     name: disability-visibility.jpg
-    size: 86514
     tint_color: '#945b9a'
   editor: Alice Wong
   publication_year: 2020

--- a/reviews/2021/doctor-who-the-pirate-planet.md
+++ b/reviews/2021/doctor-who-the-pirate-planet.md
@@ -3,7 +3,6 @@ book:
   author: Douglas Adams, James Goss
   cover:
     name: doctor-who-the-pirate-planet.jpg
-    size: 35676
     tint_color: '#1f1927'
   narrator: Jon Culshaw
   publication_year: 2017

--- a/reviews/2021/file-under-13-suspicious-incidents.md
+++ b/reviews/2021/file-under-13-suspicious-incidents.md
@@ -3,7 +3,6 @@ book:
   author: Lemony Snicket
   cover:
     name: file-under-13-suspicious-incidents.jpeg
-    size: 1338990
     tint_color: "#1d588e"
   publication_year: 2014
   title: "File Under: 13 Suspicious Incidents"

--- a/reviews/2021/finn-family-moomintroll.md
+++ b/reviews/2021/finn-family-moomintroll.md
@@ -3,7 +3,6 @@ book:
   author: Tove Jansson
   cover:
     name: finn-family-moomintroll.jpg
-    size: 65392
     tint_color: '#017d93'
   isbn13: '9781908745644'
   publication_year: 1948

--- a/reviews/2021/gender-swapped-fairy-tales.md
+++ b/reviews/2021/gender-swapped-fairy-tales.md
@@ -3,7 +3,6 @@ book:
   author: Karrie Fransman and Jonathan Plackett
   cover:
     name: gender-swapped-fairy-tales.jpg
-    size: 61157
     tint_color: '#bb2f37'
   isbn13: 978-0-571-36018-5
   publication_year: 2020

--- a/reviews/2021/going-postal.md
+++ b/reviews/2021/going-postal.md
@@ -3,7 +3,6 @@ book:
   author: Terry Pratchett
   cover:
     name: going-postal-reviewed.jpg
-    size: 29696
     tint_color: '#5e62a7'
   narrator: Stephen Briggs
   publication_year: 2014

--- a/reviews/2021/how-to-fly-a-plane.md
+++ b/reviews/2021/how-to-fly-a-plane.md
@@ -3,7 +3,6 @@ book:
   author: Nick Barnard and Lucy Pope
   cover:
     name: how-to-fly-a-plane.jpg
-    size: 38881
     tint_color: '#547290'
   isbn13: '9780500513743'
   publication_year: 2007

--- a/reviews/2021/klara-and-the-sun.md
+++ b/reviews/2021/klara-and-the-sun.md
@@ -3,7 +3,6 @@ book:
   author: Kazuo Ishiguro
   cover:
     name: klara-and-the-sun.jpg
-    size: 19757
     tint_color: '#c14327'
   isbn13: '9780571364879'
   publication_year: 2021

--- a/reviews/2021/loveless.md
+++ b/reviews/2021/loveless.md
@@ -3,7 +3,6 @@ book:
   author: Alice Oseman
   cover:
     name: loveless.jpg
-    size: 45438
     tint_color: '#914690'
   narrator: Elisabeth Hopper
   publication_year: 2020

--- a/reviews/2021/lustrum.md
+++ b/reviews/2021/lustrum.md
@@ -3,7 +3,6 @@ book:
   author: Robert Harris
   cover:
     name: lustrum.jpg
-    size: 65270
     tint_color: '#231f20'
   isbn13: '9780091801007'
   publication_year: 2009

--- a/reviews/2021/mathematics-and-politics.md
+++ b/reviews/2021/mathematics-and-politics.md
@@ -3,7 +3,6 @@ book:
   author: Alan D. Taylor and Allison M. Pacelli
   cover:
     name: mathematics-and-politics-strategy-voting-power-and-proof.jpg
-    size: 7925
     tint_color: '#42718d'
   isbn10: '1441926615'
   isbn13: '9781441926616'

--- a/reviews/2021/model-railways.md
+++ b/reviews/2021/model-railways.md
@@ -3,7 +3,6 @@ book:
   author: Cyril J. Freezer
   cover:
     name: model-railways.jpg
-    size: 37773
     tint_color: '#bf3016'
   isbn13: 0000000021296
   publication_year: 1991

--- a/reviews/2021/moominpappa-at-sea.md
+++ b/reviews/2021/moominpappa-at-sea.md
@@ -3,7 +3,6 @@ book:
   author: Tove Jansson
   cover:
     name: moominpappa-at-sea.jpg
-    size: 192777
     tint_color: '#406a82'
   isbn13: '9781908745705'
   publication_year: 1948

--- a/reviews/2021/poison-for-breakfast.md
+++ b/reviews/2021/poison-for-breakfast.md
@@ -3,7 +3,6 @@ book:
   author: Lemony Snicket
   cover:
     name: poison-for-breakfast.png
-    size: 287192
     tint_color: '#bf3625'
   publication_year: 2021
   title: Poison for Breakfast

--- a/reviews/2021/pride-and-prejudice.md
+++ b/reviews/2021/pride-and-prejudice.md
@@ -3,7 +3,6 @@ book:
   author: Jane Austen
   cover:
     name: pride-and-prejudice.jpg
-    size: 68085
     tint_color: '#947204'
   publication_year: 1813
   title: Pride and Prejudice

--- a/reviews/2021/programmed-inequality.md
+++ b/reviews/2021/programmed-inequality.md
@@ -3,7 +3,6 @@ book:
   author: Marie Hicks
   cover:
     name: programmed-inequality.jpg
-    size: 11263
     tint_color: '#4f5c91'
   isbn10: '0262035545'
   isbn13: '9780262035545'

--- a/reviews/2021/railsea.md
+++ b/reviews/2021/railsea.md
@@ -3,7 +3,6 @@ book:
   author: China Miéville
   cover:
     name: railsea.jpg
-    size: 40482
     tint_color: '#8f560e'
   isbn13: '9781447213673'
   publication_year: 2012

--- a/reviews/2021/resilient-management.md
+++ b/reviews/2021/resilient-management.md
@@ -3,7 +3,6 @@ book:
   author: Lara Hogan
   cover:
     name: resilient-management.png
-    size: 29415
     tint_color: '#b25e67'
   narrator: Lara Hogan
   publication_year: 2019

--- a/reviews/2021/small-bodies-of-water.md
+++ b/reviews/2021/small-bodies-of-water.md
@@ -3,7 +3,6 @@ book:
   author: Nina Mingya Powles
   cover:
     name: small-bodies-of-water.jpg
-    size: 48189
     tint_color: '#0967b2'
   narrator: Nina Mingya Powles
   publication_year: 2021

--- a/reviews/2021/solutions-and-other-problems.md
+++ b/reviews/2021/solutions-and-other-problems.md
@@ -3,7 +3,6 @@ book:
   author: Allie Brosh
   cover:
     name: solutions-and-other-problems.jpg
-    size: 45933
     tint_color: '#0dc59a'
   isbn13: '9780224101288'
   publication_year: 2020

--- a/reviews/2021/surviving-the-storms.md
+++ b/reviews/2021/surviving-the-storms.md
@@ -3,7 +3,6 @@ book:
   author: the RNLI
   cover:
     name: surviving-the-storms.jpg
-    size: 33119
     tint_color: '#0c6e79'
   isbn13: '9780008390129'
   publication_year: 2020

--- a/reviews/2021/tales-from-moominvalley.md
+++ b/reviews/2021/tales-from-moominvalley.md
@@ -3,7 +3,6 @@ book:
   author: Tove Jansson
   cover:
     name: tales-from-moominvalley.jpg
-    size: 31505
     tint_color: '#404e46'
   isbn13: '9781908745682'
   publication_year: 1962

--- a/reviews/2021/the-apollo-murders.md
+++ b/reviews/2021/the-apollo-murders.md
@@ -3,7 +3,6 @@ book:
   author: Chris Hadfield
   cover:
     name: the-apollo-murders.jpg
-    size: 49761
     tint_color: '#1e1e1e'
   isbn13: '9781529417456'
   publication_year: 2021

--- a/reviews/2021/the-backwater-sermons.md
+++ b/reviews/2021/the-backwater-sermons.md
@@ -3,7 +3,6 @@ book:
   author: Jay Hulme
   cover:
     name: the-backwater-sermons.jpg
-    size: 49424
     tint_color: '#936f4a'
   isbn13: '9781786223937'
   publication_year: 2021

--- a/reviews/2021/the-box-in-the-woods.md
+++ b/reviews/2021/the-box-in-the-woods.md
@@ -5,7 +5,6 @@ book:
   series: 'Truly Devious #4'
   cover:
     name: the-box-in-the-woods.jpg
-    size: 421054
     tint_color: '#674288'
   publication_year: 2021
   title: The Box in the Woods

--- a/reviews/2021/the-boy-who-drew-auschwitz.md
+++ b/reviews/2021/the-boy-who-drew-auschwitz.md
@@ -3,7 +3,6 @@ book:
   author: Thomas Geve
   cover:
     name: the-boy-who-drew-auschwitz.jpg
-    size: 67311
     tint_color: '#706a62'
   publication_year: 2021
   title: The Boy Who Drew Auschwitz

--- a/reviews/2021/the-cyberiad.md
+++ b/reviews/2021/the-cyberiad.md
@@ -3,7 +3,6 @@ book:
   author: Stanislaw Lem
   cover:
     name: the-cyberiad.jpg
-    size: 87822
     tint_color: '#805385'
   isbn13: '9780241467992'
   publication_year: 1965

--- a/reviews/2021/the-distant-hours.md
+++ b/reviews/2021/the-distant-hours.md
@@ -3,7 +3,6 @@ book:
   author: Kate Morton
   cover:
     name: the-distant-hours.jpg
-    size: 54471
     tint_color: '#62769d'
   isbn13: '9780330477581'
   publication_year: 2010

--- a/reviews/2021/the-galaxy-and-the-ground-within.md
+++ b/reviews/2021/the-galaxy-and-the-ground-within.md
@@ -3,7 +3,6 @@ book:
   author: Becky Chambers
   cover:
     name: the-galaxy-and-the-ground-within.jpg
-    size: 26746
     tint_color: '#9d418d'
   isbn13: '9781529362947'
   publication_year: 2021

--- a/reviews/2021/the-hand-on-the-wall.md
+++ b/reviews/2021/the-hand-on-the-wall.md
@@ -3,7 +3,6 @@ book:
   author: Maureen Johnson
   cover:
     name: the-hand-on-the-wall.jpg
-    size: 48898
     tint_color: '#0ba867'
   narrator: Kate Rudd
   publication_year: 2020

--- a/reviews/2021/the-invisible-child-and-the-fir-tree.md
+++ b/reviews/2021/the-invisible-child-and-the-fir-tree.md
@@ -3,7 +3,6 @@ book:
   author: Tove Jansson
   cover:
     name: the-invisible-child-and-the-fir-tree.jpg
-    size: 47948
     tint_color: '#bb3f40'
   isbn13: '9781908745743'
   publication_year: 1962

--- a/reviews/2021/the-kabuliwallah-and-other-stories.md
+++ b/reviews/2021/the-kabuliwallah-and-other-stories.md
@@ -3,7 +3,6 @@ book:
   author: Rabindranath Tagore
   cover:
     name: the-kabuliwallah-and-other-stories.jpg
-    size: 42638
     tint_color: '#c01b1b'
   publication_year: 2020
   title: The Kabuliwallah and Other Stories

--- a/reviews/2021/the-last-lingua-franca.md
+++ b/reviews/2021/the-last-lingua-franca.md
@@ -3,7 +3,6 @@ book:
   author: Nicholas Ostler
   cover:
     name: the-last-lingua-franca.jpg
-    size: 19915
     tint_color: '#787266'
   isbn13: '9781846142154'
   publication_year: 2010

--- a/reviews/2021/the-library-of-the-dead.md
+++ b/reviews/2021/the-library-of-the-dead.md
@@ -4,7 +4,6 @@ book:
   narrator: Tinashe Warikandwa
   cover:
     name: the-library-of-the-dead.jpeg
-    size: 549831
     tint_color: "#206969"
   publication_year: 2021
   title: The Library of the Dead

--- a/reviews/2021/the-martian.md
+++ b/reviews/2021/the-martian.md
@@ -3,7 +3,6 @@ book:
   author: Andy Weir
   cover:
     name: the-martian.jpg
-    size: 12293
     tint_color: '#fe5b29'
   narrator: Wil Wheaton
   publication_year: 2011

--- a/reviews/2021/the-only-plane-in-the-sky.md
+++ b/reviews/2021/the-only-plane-in-the-sky.md
@@ -3,7 +3,6 @@ book:
   author: Garrett M. Graff
   cover:
     name: the-only-plane-in-the-sky.jpg
-    size: 19351
     tint_color: '#000000'
   narrator: Holter Graham and a full cast
   publication_year: 2019

--- a/reviews/2021/the-otters-tale.md
+++ b/reviews/2021/the-otters-tale.md
@@ -3,7 +3,6 @@ book:
   author: Simon Cooper
   cover:
     name: the-otters-tale.jpg
-    size: 48156
     tint_color: "#164060"
   publication_year: 2017
   title: "The Otters' Tale"

--- a/reviews/2021/the-penguin-dictionary-of-curious-and-interesting-numbers.md
+++ b/reviews/2021/the-penguin-dictionary-of-curious-and-interesting-numbers.md
@@ -3,7 +3,6 @@ book:
   author: David Wells
   cover:
     name: the-penguin-dictionary-of-curious-and-interesting-numbers.jpg
-    size: 32778
     tint_color: '#7f6634'
   isbn10: 0140261494
   isbn13: '9780140261493'

--- a/reviews/2021/the-power-of-the-a4s.md
+++ b/reviews/2021/the-power-of-the-a4s.md
@@ -3,7 +3,6 @@ book:
   author: Brian Morrison
   cover:
     name: the-power-of-the-a4s.jpg
-    size: 112001
     tint_color: "#2e3167"
   publication_year: 1978
   title: The Power of the A4s

--- a/reviews/2021/the-underground-railroad.md
+++ b/reviews/2021/the-underground-railroad.md
@@ -3,7 +3,6 @@ book:
   author: Colson Whitehead
   cover:
     name: the-underground-railroad.jpg
-    size: 23713
     tint_color: '#845657'
   narrator: Bahni Turpin
   publication_year: 2016

--- a/reviews/2021/the-vanishing-stair.md
+++ b/reviews/2021/the-vanishing-stair.md
@@ -3,7 +3,6 @@ book:
   author: Maureen Johnson
   cover:
     name: the-vanishing-stair.jpg
-    size: 44546
     tint_color: '#b5483d'
   narrator: Kate Rudd
   publication_year: 2019

--- a/reviews/2021/the-vela-season-1.md
+++ b/reviews/2021/the-vela-season-1.md
@@ -3,7 +3,6 @@ book:
   author: Yoon Ha Lee, Becky Chambers, Rivers Solomon, S.L. Huang
   cover:
     name: the-vela-season-1.jpg
-    size: 46150
     tint_color: '#345f76'
   narrator: Robin Miles
   publication_year: 2019

--- a/reviews/2021/the-woman-in-cabin-10.md
+++ b/reviews/2021/the-woman-in-cabin-10.md
@@ -3,7 +3,6 @@ book:
   author: Ruth Ware
   cover:
     name: the-woman-in-cabin-10.jpg
-    size: 21476
     tint_color: '#12555a'
   narrator: Imogen Church
   publication_year: 2016

--- a/reviews/2021/think-black.md
+++ b/reviews/2021/think-black.md
@@ -3,7 +3,6 @@ book:
   author: Clyde W. Ford
   cover:
     name: think-black.jpg
-    size: 11303
     tint_color: '#353535'
   publication_year: 2019
   title: Think Black

--- a/reviews/2021/trains.md
+++ b/reviews/2021/trains.md
@@ -4,7 +4,6 @@ book:
   illustrator: Martin Aitchison, Gerald Witcomb, Robert Ayton and John Berry
   cover:
     name: trains.jpg
-    size: 48552
     tint_color: "#b82b1d"
   publication_year: 1974
   title: Trains

--- a/reviews/2021/truly-devious.md
+++ b/reviews/2021/truly-devious.md
@@ -3,7 +3,6 @@ book:
   author: Maureen Johnson
   cover:
     name: truly-devious.jpg
-    size: 47196
     tint_color: '#393977'
   narrator: Kate Rudd
   publication_year: 2018

--- a/reviews/2021/what-cats-want.md
+++ b/reviews/2021/what-cats-want.md
@@ -3,7 +3,6 @@ book:
   author: Dr. Yuki Hattori
   cover:
     name: what-cats-want.jpg
-    size: 490
     tint_color: "#707072"
   publication_year: 2020
   title: What Cats Want

--- a/reviews/2021/written-in-the-stars.md
+++ b/reviews/2021/written-in-the-stars.md
@@ -3,7 +3,6 @@ book:
   author: Alexandria Bellefleur
   cover:
     name: written-in-the-stars.jpg
-    size: 29086
     tint_color: '#0f5987'
   narrator: Lauren Sweet
   publication_year: 2020

--- a/reviews/2021/your-computer-is-on-fire.md
+++ b/reviews/2021/your-computer-is-on-fire.md
@@ -2,7 +2,6 @@
 book:
   cover:
     name: your-computer-is-on-fire.jpg
-    size: 32343
     tint_color: '#988206'
   editor: Thomas S. Mullaney, Benjamin Peters, Mar Hicks, and Kavita Philip
   isbn13: '9780262539739'

--- a/reviews/2022/a-psalm-for-the-wild-built.md
+++ b/reviews/2022/a-psalm-for-the-wild-built.md
@@ -3,7 +3,6 @@ book:
   author: Becky Chambers
   cover:
     name: a-psalm-for-the-wild-built.jpg
-    size: 922516
     tint_color: "#917546"
   publication_year: 2021
   title: A Psalm for the Wild-Built

--- a/reviews/2022/count-your-lucky-stars.md
+++ b/reviews/2022/count-your-lucky-stars.md
@@ -3,7 +3,6 @@ book:
   author: Alexandria Bellefleur
   cover:
     name: count-your-lucky-stars.jpg
-    size: 257642
     tint_color: "#285263"
   title: Count Your Lucky Stars
   publication_year: 2022

--- a/reviews/2022/doctor-who-respond-to-all-calls.md
+++ b/reviews/2022/doctor-who-respond-to-all-calls.md
@@ -3,7 +3,6 @@ book:
   author: Lisa McMullin, Tim Foley, and Timothy X. Atack
   cover:
     name: doctor-who-respond-to-all-calls.jpg
-    size: 144419
     tint_color: "#b32641"
   title: "Doctor Who: Respond to All Calls"
   publication_year: 2021

--- a/reviews/2022/hang-the-moon.md
+++ b/reviews/2022/hang-the-moon.md
@@ -3,7 +3,6 @@ book:
   author: Alexandria Bellefleur
   cover:
     name: hang-the-moon.jpg
-    size: 245716
     tint_color: "#965792"
   publication_year: 2021
   title: Hang the Moon

--- a/reviews/2022/historic-railway-disasters.md
+++ b/reviews/2022/historic-railway-disasters.md
@@ -3,7 +3,6 @@ book:
   author: O. S. Nock
   cover:
     name: historic-railway-disasters.jpg
-    size: 1890225
     tint_color: "#2b6183"
   publication_year: 1983
   title: Historic Railway Disasters

--- a/reviews/2022/homers-the-iliad-and-the-odyssey.md
+++ b/reviews/2022/homers-the-iliad-and-the-odyssey.md
@@ -3,7 +3,6 @@ book:
   author: Alberto Manguel
   cover:
     name: homers-the-iliad-and-the-odyssey.jpg
-    size: 210618
     tint_color: "#587c1d"
   publication_year: 2007
   title: "Homer's The Iliad and the Odyssey"

--- a/reviews/2022/kigelia-a-typeface-for-africa.md
+++ b/reviews/2022/kigelia-a-typeface-for-africa.md
@@ -3,7 +3,6 @@ book:
   author: Mark Jamra and Neil Patel
   cover:
     name: kigelia-a-typeface-for-africa.jpg
-    size: 158583
     tint_color: "#b25405"
   title: "Kigelia: A Typeface for Africa"
   publication_year: 2018

--- a/reviews/2022/light-years.md
+++ b/reviews/2022/light-years.md
@@ -3,7 +3,6 @@ book:
   author: Brian Clegg
   cover:
     name: light-years.jpg
-    size: 26293
     tint_color: "#10213f"
   title: Light Years
   publication_year: 2008

--- a/reviews/2022/never-lost-again.md
+++ b/reviews/2022/never-lost-again.md
@@ -4,7 +4,6 @@ book:
   narrator: Robert Shapiro
   cover:
     name: never-lost-again.jpg
-    size: 58176
     tint_color: "#167dab"
   title: Never Lost Again
   publication_year: 2018

--- a/reviews/2022/palestine-100.md
+++ b/reviews/2022/palestine-100.md
@@ -3,7 +3,6 @@ book:
   editor: Basma Ghalayini
   cover:
     name: palestine-100.jpg
-    size: 525009
     tint_color: "#b05f40"
   publication_year: 2019
   title: "Palestine + 100"

--- a/reviews/2022/physics-of-the-impossible.md
+++ b/reviews/2022/physics-of-the-impossible.md
@@ -3,7 +3,6 @@ book:
   author: Michio Kaku
   cover:
     name: physics-of-the-impossible.jpg
-    size: 245070
     tint_color: "#7b512d"
   publication_year: 2008
   title: Physics of the Impossible

--- a/reviews/2022/piranesi.md
+++ b/reviews/2022/piranesi.md
@@ -4,7 +4,6 @@ book:
   narrator: Chiwetel Ejiofor
   cover:
     name: piranesi.jpg
-    size: 1992812
     tint_color: "#916540"
   publication_year: 2020
   title: Piranesi

--- a/reviews/2022/the-calculating-stars.md
+++ b/reviews/2022/the-calculating-stars.md
@@ -4,7 +4,6 @@ book:
   narrator: Mary Robinette Kowal
   cover:
     name: the-calculating-stars.jpg
-    size: 1808117
     tint_color: "#296a93"
   publication_year: 2018
   title: The Calculating Stars

--- a/reviews/2022/the-compendium-of-not-quite-everything.md
+++ b/reviews/2022/the-compendium-of-not-quite-everything.md
@@ -3,7 +3,6 @@ book:
   author: Jonn Elledge
   cover:
     name: the-compendium-of-not-quite-everything.png
-    size: 1245070
     tint_color: "#094685"
   title: The Compendium of (Not Quite) Everything
   publication_year: 2021

--- a/reviews/2022/the-distance-between-me-and-the-cherry-tree.md
+++ b/reviews/2022/the-distance-between-me-and-the-cherry-tree.md
@@ -5,7 +5,6 @@ book:
   translated_by: Denise Muir
   cover:
     name: the-distance-between-me-and-the-cherry-tree.jpg
-    size: 79956
     tint_color: "#132c44"
   publication_year: 2018
   title: The Distance Between Me and the Cherry Tree

--- a/reviews/2022/the-haunting-of-tram-car-015.md
+++ b/reviews/2022/the-haunting-of-tram-car-015.md
@@ -4,7 +4,6 @@ book:
   narrator: Julian Thomas
   cover:
     name: the-haunting-of-tram-car-015.jpg
-    size: 97462
     tint_color: "#975b29"
   publication_year: 2019
   title: The Haunting of Tram Car 015

--- a/reviews/2022/the-most-precious-of-cargoes.md
+++ b/reviews/2022/the-most-precious-of-cargoes.md
@@ -4,7 +4,6 @@ book:
   translated_by: Frank Wynne
   cover:
     name: the-most-precious-of-cargoes.jpg
-    size: 1127925
     tint_color: "#6d868b"
   title: The Most Precious of Cargoes
   publication_year: 2019

--- a/reviews/2022/the-wombles.md
+++ b/reviews/2022/the-wombles.md
@@ -3,7 +3,6 @@ book:
   author: Elisabeth Beresford
   cover:
     name: the-wombles.jpg
-    size: 198104
     tint_color: "#578132"
   title: The Wombles
   publication_year: 1968

--- a/reviews/2022/there-is-no-antimemetics-division.md
+++ b/reviews/2022/there-is-no-antimemetics-division.md
@@ -3,7 +3,6 @@ book:
   author: qntm
   cover:
     name: there-is-no-antimemetics-division.jpg
-    size: 133742
     tint_color: "#dd4366"
   title: There Is No Antimemetics Division
   publication_year: 2021

--- a/reviews/2022/we-need-to-talk.md
+++ b/reviews/2022/we-need-to-talk.md
@@ -3,7 +3,6 @@ book:
   author: Celeste Headlee
   cover:
     name: we-need-to-talk.jpg
-    size: 88169
     tint_color: "#be7d0e"
   title: We Need to Talk
   publication_year: 2017

--- a/reviews/2022/your-guide-to-not-getting-murdered-in-a-quaint-english-village.md
+++ b/reviews/2022/your-guide-to-not-getting-murdered-in-a-quaint-english-village.md
@@ -4,7 +4,6 @@ book:
   illustrator: Jay Cooper
   cover:
     name: your-guide-to-not-getting-murdered-in-a-quaint-english-village.jpg
-    size: 213768
     tint_color: "#c60017"
   publication_year: 2021
   title: Your Guide to Not Getting Murdered in a Quaint English Village

--- a/reviews/other-times/agent-zigzag.md
+++ b/reviews/other-times/agent-zigzag.md
@@ -3,7 +3,6 @@ book:
   author: Ben Macintyre
   cover:
     name: agent-zigzag.jpg
-    size: 20132
     tint_color: '#97413f'
   isbn10: '1408811499'
   isbn13: '9781408811498'

--- a/reviews/other-times/artemis-fowl-and-the-lost-colony.md
+++ b/reviews/other-times/artemis-fowl-and-the-lost-colony.md
@@ -3,7 +3,6 @@ book:
   author: Eoin Colfer
   cover:
     name: artemis-fowl-and-the-lost-colony.jpg
-    size: 9485
     tint_color: '#933a3a'
   isbn10: 1-4056-6148-8
   isbn13: 978-1-4056-6148-5

--- a/reviews/other-times/artemis-fowl-and-the-opal-deception.md
+++ b/reviews/other-times/artemis-fowl-and-the-opal-deception.md
@@ -3,7 +3,6 @@ book:
   author: Eoin Colfer
   cover:
     name: artemis-fowl-and-the-opal-deception.jpg
-    size: 9736
     tint_color: '#06397a'
   isbn10: 0-14-132059-1
   isbn13: 978-0-14-132059-5

--- a/reviews/other-times/artemis-fowl-and-the-time-paradox.md
+++ b/reviews/other-times/artemis-fowl-and-the-time-paradox.md
@@ -3,7 +3,6 @@ book:
   author: Eoin Colfer
   cover:
     name: artemis-fowl-and-the-time-paradox.gif
-    size: 42027
     tint_color: '#8e7024'
   isbn10: 0-14-132220-9
   isbn13: 978-0-14-132220-9

--- a/reviews/other-times/artemis-fowl-eternity-cube.md
+++ b/reviews/other-times/artemis-fowl-eternity-cube.md
@@ -3,7 +3,6 @@ book:
   author: Eoin Colfer
   cover:
     name: artemis-fowl-eternity-cube.jpg
-    size: 7572
     tint_color: '#b52b1e'
   isbn10: 0-14-131548-2
   isbn13: 978-0-14-131548-5

--- a/reviews/other-times/artemis-fowl-the-arctic-incident.md
+++ b/reviews/other-times/artemis-fowl-the-arctic-incident.md
@@ -3,7 +3,6 @@ book:
   author: Eoin Colfer
   cover:
     name: artemis-fowl-the-arctic-incident.jpg
-    size: 6643
     tint_color: '#70726f'
   isbn10: 0-7569-2803-6
   isbn13: 978-0-7569-2803-2

--- a/reviews/other-times/artemis-fowl.md
+++ b/reviews/other-times/artemis-fowl.md
@@ -3,7 +3,6 @@ book:
   author: Eoin Colfer
   cover:
     name: artemis-fowl.jpg
-    size: 8525
     tint_color: '#8b630a'
   isbn10: 0-14-135639-1
   isbn13: 978-0-14-135639-6

--- a/reviews/other-times/cambridge-student-pranks.md
+++ b/reviews/other-times/cambridge-student-pranks.md
@@ -3,7 +3,6 @@ book:
   author: Jamie Collinson
   cover:
     name: cambridge-student-pranks.jpg
-    size: 111986
     tint_color: '#107d92'
   publication_year: 2010
   title: Cambridge Student Pranks

--- a/reviews/other-times/creativity-inc.md
+++ b/reviews/other-times/creativity-inc.md
@@ -3,7 +3,6 @@ book:
   author: Ed Catmull
   cover:
     name: creativity-inc.jpg
-    size: 7563
     tint_color: '#ca232a'
   isbn10: 0593070097
   isbn13: '9780593070093'

--- a/reviews/other-times/do-you-feel-lucky.md
+++ b/reviews/other-times/do-you-feel-lucky.md
@@ -3,7 +3,6 @@ book:
   author: Kjartan Poskitt
   cover:
     name: do-you-feel-lucky.jpg
-    size: 7979
     tint_color: '#447686'
   isbn10: 0-439-99607-4
   isbn13: 978-0-439-99607-5

--- a/reviews/other-times/double-cross.md
+++ b/reviews/other-times/double-cross.md
@@ -3,7 +3,6 @@ book:
   author: Ben Macintyre
   cover:
     name: double-cross.jpg
-    size: 11286
     tint_color: '#8e722f'
   isbn10: '1408830620'
   isbn13: '9781408830628'

--- a/reviews/other-times/five-go-on-a-strategy-away-day.md
+++ b/reviews/other-times/five-go-on-a-strategy-away-day.md
@@ -3,7 +3,6 @@ book:
   author: Bruno Vincent
   cover:
     name: five-go-on-a-strategy-away-day.jpg
-    size: 11607
     tint_color: '#b8392f'
   isbn10: 178648224X
   isbn13: '9781786482242'

--- a/reviews/other-times/have-i-got-views-for-you.md
+++ b/reviews/other-times/have-i-got-views-for-you.md
@@ -3,7 +3,6 @@ book:
   author: Boris Johnson
   cover:
     name: have-i-got-views-for-you.jpg
-    size: 6979
     tint_color: '#b63d47'
   isbn10: 0-00-729096-9
   isbn13: 978-0-00-729096-3

--- a/reviews/other-times/how-many-friends-does-one-person-need.md
+++ b/reviews/other-times/how-many-friends-does-one-person-need.md
@@ -3,7 +3,6 @@ book:
   author: Robin I.M. Dunbar
   cover:
     name: how-many-friends-does-one-person-need.jpg
-    size: 12562
     tint_color: '#9d4a52'
   isbn10: '0571253423'
   isbn13: '9780571253425'

--- a/reviews/other-times/inside-steves-brain.md
+++ b/reviews/other-times/inside-steves-brain.md
@@ -3,7 +3,6 @@ book:
   author: Leander Kahney
   cover:
     name: inside-steves-brain.jpg
-    size: 8011
     tint_color: '#636466'
   isbn10: '1843549123'
   isbn13: '9781843549123'

--- a/reviews/other-times/math-hysteria-fun-and-games-with-mathematics.md
+++ b/reviews/other-times/math-hysteria-fun-and-games-with-mathematics.md
@@ -3,7 +3,6 @@ book:
   author: Ian Stewart
   cover:
     name: math-hysteria-fun-and-games-with-mathematics.jpg
-    size: 11697
     tint_color: '#587f8d'
   isbn13: 978-0-19-861336-7
   publication_year: 2004

--- a/reviews/other-times/not-quite-human-bug-in-the-system.md
+++ b/reviews/other-times/not-quite-human-bug-in-the-system.md
@@ -3,7 +3,6 @@ book:
   author: Seth McEvoy
   cover:
     name: not-quite-human-bug-in-the-system.jpg
-    size: 11864
     tint_color: '#986a43'
   isbn10: 0583309844
   isbn13: '9780583309844'

--- a/reviews/other-times/number-9-the-search-for-the-sigma-code.md
+++ b/reviews/other-times/number-9-the-search-for-the-sigma-code.md
@@ -3,7 +3,6 @@ book:
   author: Cecil Balmond
   cover:
     name: number-9-the-search-for-the-sigma-code.jpg
-    size: 17834
     tint_color: '#8c623c'
   isbn10: '3791340670'
   isbn13: '9783791340678'

--- a/reviews/other-times/numbers.md
+++ b/reviews/other-times/numbers.md
@@ -3,7 +3,6 @@ book:
   author: Kjartan Poskitt
   cover:
     name: numbers.jpg
-    size: 7874
     tint_color: '#736a80'
   isbn10: 0-439-98116-6
   isbn13: 978-0-439-98116-3

--- a/reviews/other-times/operation-mincemeat.md
+++ b/reviews/other-times/operation-mincemeat.md
@@ -3,7 +3,6 @@ book:
   author: Ben Macintyre
   cover:
     name: operation-mincemeat.jpg
-    size: 1508412
     tint_color: '#988c6b'
   publication_year: 2010
   title: Operation Mincemeat

--- a/reviews/other-times/space-stories-that-really-happened.md
+++ b/reviews/other-times/space-stories-that-really-happened.md
@@ -3,7 +3,6 @@ book:
   author: Andrew Donkin, David Wyatt
   cover:
     name: space-stories-that-really-happened.jpg
-    size: 7406
     tint_color: '#4e6168'
   isbn10: 0-590-11103-5
   isbn13: 978-0-590-11103-4

--- a/reviews/other-times/the-end-of-harry-potter.md
+++ b/reviews/other-times/the-end-of-harry-potter.md
@@ -3,7 +3,6 @@ book:
   author: David Langford
   cover:
     name: the-end-of-harry-potter.jpg
-    size: 43541
     tint_color: "#7e4529"
   publication_year: 2006
   title: The End of Harry Potter?

--- a/reviews/other-times/the-phantom-x.md
+++ b/reviews/other-times/the-phantom-x.md
@@ -3,7 +3,6 @@ book:
   author: Kjartan Poskitt
   cover:
     name: the-phantom-x.jpg
-    size: 8844
     tint_color: '#c9252d'
   isbn10: 1-4071-0713-5
   isbn13: 978-1-4071-0713-4

--- a/reviews/other-times/the-sixth-form-at-st-clares.md
+++ b/reviews/other-times/the-sixth-form-at-st-clares.md
@@ -3,7 +3,6 @@ book:
   author: Pamela Cox
   cover:
     name: the-sixth-form-at-st-clares.jpg
-    size: 13609
     tint_color: '#716bae'
   isbn10: 0749742690
   isbn13: '9780749742690'

--- a/reviews/other-times/the-tales-of-beedle-the-bard.md
+++ b/reviews/other-times/the-tales-of-beedle-the-bard.md
@@ -3,7 +3,6 @@ book:
   author: J.K. Rowling
   cover:
     name: the-tales-of-beedle-the-bard.jpg
-    size: 12691
     tint_color: '#546d89'
   isbn10: 0747599874
   isbn13: '9780747599876'

--- a/reviews/other-times/the-worst-case-scenario-survival-handbook-travel.md
+++ b/reviews/other-times/the-worst-case-scenario-survival-handbook-travel.md
@@ -3,7 +3,6 @@ book:
   author: Joshua Piven
   cover:
     name: the-worst-case-scenario-survival-handbook-travel.jpg
-    size: 9658
     tint_color: '#000000'
   isbn10: 0811831310
   isbn13: '9780811831314'

--- a/reviews/other-times/the-worst-case-scenario-survival-handbook.md
+++ b/reviews/other-times/the-worst-case-scenario-survival-handbook.md
@@ -3,7 +3,6 @@ book:
   author: Joshua Piven
   cover:
     name: the-worst-case-scenario-survival-handbook.jpg
-    size: 6389
     tint_color: '#9c5722'
   isbn10: 0811825558
   isbn13: '9780811825559'

--- a/reviews/other-times/the-worst-witch-all-at-sea.md
+++ b/reviews/other-times/the-worst-witch-all-at-sea.md
@@ -3,7 +3,6 @@ book:
   author: Jill Murphy
   cover:
     name: the-worst-witch-all-at-sea.jpg
-    size: 6631
     tint_color: '#2f724e'
   isbn10: 014034389X
   isbn13: '9780140343892'

--- a/reviews/other-times/the-worst-witch.md
+++ b/reviews/other-times/the-worst-witch.md
@@ -3,7 +3,6 @@ book:
   author: Jill Murphy
   cover:
     name: the-worst-witch.jpg
-    size: 6600
     tint_color: '#766397'
   isbn10: 0140311084
   isbn13: '9780140311082'

--- a/src/add_review.rs
+++ b/src/add_review.rs
@@ -212,8 +212,6 @@ pub fn add_review() -> () {
 
     let cover_name = cover_path.file_name().unwrap().to_str().unwrap();
 
-    let cover_size = fs::metadata(&cover_path).unwrap().len();
-
     let output = String::from_utf8(
         Command::new("dominant_colours")
             .arg(&cover_path)
@@ -270,7 +268,6 @@ pub fn add_review() -> () {
 
     let cover = models::Cover {
         name: cover_name.to_string(),
-        size: cover_size as i32,
         tint_color: tint_colour.to_string(),
     };
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -13,7 +13,6 @@ fn default_as_false() -> bool {
 #[derive(Deserialize, Serialize)]
 pub struct Cover {
     pub name: String,
-    pub size: i32,
     pub tint_color: String,
 }
 


### PR DESCRIPTION
This is a field I used in an older version of the site generator to decide when to regenerate thumbnails.  Now I use the modified time from the filesystem metadata, so I don't need to track this separately.