### PR TITLE
Don't panic when you can't connect to GitHub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.3.10 - 2022-06-29
+
+Fix a bug where `vfd build` would panic when trying to check the latest version if it was unable to connect to the GitHub API, e.g. if the Internet connection was offline.
+
 ## v1.3.9 - 2022-06-23
 
 When adding a review, vfd now opens a pre-filled Google Images search for possible covers to help me pick a cover image.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2902,7 +2902,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vfd"
-version = "1.3.9"
+version = "1.3.10"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfd"
-version = "1.3.9"
+version = "1.3.10"
 edition = "2021"
 
 [dependencies]

--- a/src/version.rs
+++ b/src/version.rs
@@ -27,8 +27,7 @@ pub async fn get_latest_version() -> Result<Option<String>, reqwest::Error> {
                 "alexwlchan (via https://github.com/alexwlchan/books.alexwlchan.net)",
             )
             .send(),
-    )
-    .unwrap();
+    )?;
 
     // Return an error if we don't get a 200 OK status code.
     let resp = resp.error_for_status()?;


### PR DESCRIPTION
Previously this threw the following error:

    thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value:

    reqwest::Error {
      kind: Request,
      url: Url {
        scheme: "https",
        cannot_be_a_base: false,
        username: "",
        password: None,
        host: Some(Domain("api.github.com")),
        port: None,
        path: "/repos/alexwlchan/books.alexwlchan.net/releases/latest",
        query: None,
        fragment: None
      },
      source: hyper::Error(
        Connect,
        ConnectError(
          "dns error",
          Custom {
            kind: Uncategorized,
            error: "failed to lookup address information: nodename nor servname provided, or not known"
          }
        )
      )
    }', src/version.rs:31:6

(Guess who just tried to build the site while offline!)