### PR TITLE
Pass cover information to the templates; use it to declare image dimensions upfront

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v1.3.13 - 2022-06-29
+
+Fetch the dimensions of cover images and pass it to templates, so this information can be passed in the CSS on the `/review` page to simplify page layout.
+
+In particular, now we can give exact dimensions for images *before* the browser loads them, so the page doesn't need to be continually re-laid out as images are loaded.
+
 ## v1.3.12 - 2022-06-29
 
 Tweak the way shelves are generated, so there's more variety of light/dark books on different pages.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2943,7 +2943,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vfd"
-version = "1.3.12"
+version = "1.3.13"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfd"
-version = "1.3.12"
+version = "1.3.13"
 edition = "2021"
 
 [dependencies]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,6 +11,7 @@ pub enum VfdError {
     Walk(walkdir::Error),
     Parse(serde_yaml::Error, PathBuf),
     Utf8(std::str::Utf8Error, PathBuf),
+    CoverInfo(ImageError, PathBuf),
     Thumbnail(ImageError),
     Template(tera::Error),
     HtmlMinification(HTMLMinifierError),
@@ -27,6 +28,7 @@ impl fmt::Display for VfdError {
             VfdError::Utf8(ref err, ref path) => {
                 write!(f, "Couldn't read {:?} as a UTF-8 string: {}", path, err)
             }
+            VfdError::CoverInfo(ref err, ref path) => write!(f, "Error getting cover info for {:?}: {}", path, err),
             VfdError::Thumbnail(ref err) => write!(f, "Couldn't create thumbnail: {:?}", err),
             VfdError::Template(ref err) => write!(f, "Error rendering the template: {:?}", err),
             VfdError::HtmlMinification(ref err) => write!(f, "Error minifying the HTML: {:?}", err),

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -28,7 +28,9 @@ impl fmt::Display for VfdError {
             VfdError::Utf8(ref err, ref path) => {
                 write!(f, "Couldn't read {:?} as a UTF-8 string: {}", path, err)
             }
-            VfdError::CoverInfo(ref err, ref path) => write!(f, "Error getting cover info for {:?}: {}", path, err),
+            VfdError::CoverInfo(ref err, ref path) => {
+                write!(f, "Error getting cover info for {:?}: {}", path, err)
+            }
             VfdError::Thumbnail(ref err) => write!(f, "Couldn't create thumbnail: {:?}", err),
             VfdError::Template(ref err) => write!(f, "Error rendering the template: {:?}", err),
             VfdError::HtmlMinification(ref err) => write!(f, "Error minifying the HTML: {:?}", err),

--- a/src/models.rs
+++ b/src/models.rs
@@ -80,12 +80,19 @@ pub struct Metadata {
 }
 
 #[derive(Deserialize, Serialize)]
+pub struct DerivedCoverInfo {
+    pub width: u32,
+    pub height: u32,
+}
+
+#[derive(Deserialize, Serialize)]
 pub struct Review {
     pub book: Book,
     pub review: Option<ReviewMetadata>,
     pub text: String,
     pub slug: String,
     pub path: PathBuf,
+    pub derived_cover_info: DerivedCoverInfo,
 }
 
 pub fn year_read(rev: &Review) -> &str {

--- a/src/render_html.rs
+++ b/src/render_html.rs
@@ -56,11 +56,9 @@ fn get_reviews(root: &Path) -> Result<Vec<models::Review>, VfdError> {
             let cover_path = PathBuf::from("covers").join(&book.cover.name);
             let (width, height) = match image::image_dimensions(&cover_path) {
                 Ok(dim) => dim,
-                Err(e)  => return Err(VfdError::CoverInfo(e, cover_path)),
+                Err(e) => return Err(VfdError::CoverInfo(e, cover_path)),
             };
-            let derived_cover_info = models::DerivedCoverInfo {
-                width, height,
-            };
+            let derived_cover_info = models::DerivedCoverInfo { width, height };
 
             result.push(models::Review {
                 book,

--- a/src/render_html.rs
+++ b/src/render_html.rs
@@ -53,12 +53,22 @@ fn get_reviews(root: &Path) -> Result<Vec<models::Review>, VfdError> {
             let review = metadata.review;
             let book = metadata.book;
 
+            let cover_path = PathBuf::from("covers").join(&book.cover.name);
+            let (width, height) = match image::image_dimensions(&cover_path) {
+                Ok(dim) => dim,
+                Err(e)  => return Err(VfdError::CoverInfo(e, cover_path)),
+            };
+            let derived_cover_info = models::DerivedCoverInfo {
+                width, height,
+            };
+
             result.push(models::Review {
                 book,
                 review,
                 slug,
                 text,
                 path: path.to_owned(),
+                derived_cover_info,
             });
         }
     }

--- a/templates/_review_entry.html
+++ b/templates/_review_entry.html
@@ -26,9 +26,9 @@ id="review_preview_{{ slug }}">
         -->
       <span class="thumbnail_helper"></span>
       {% if cover_dimensions.width > cover_dimensions.height %}
-        <img src="/thumbnails/{{ book.cover.name }}" style="width: 130px; height: {{ cover_dimensions.height * 130 }} / cover_dimensions.width | round}}px;">
+        <img src="/thumbnails/{{ book.cover.name }}" style="width: 130px; height: {{ cover_dimensions.height * 130 }} / cover_dimensions.width | round}}px;" loading="lazy">
       {% else %}
-        <img src="/thumbnails/{{ book.cover.name }}" style="height: 130px; width: {{ cover_dimensions.width * 130 / cover_dimensions.height | round }}px;">
+        <img src="/thumbnails/{{ book.cover.name }}" style="height: 130px; width: {{ cover_dimensions.width * 130 / cover_dimensions.height | round }}px;" loading="lazy">
       {% endif %}
       <span class="thumbnail_helper"></span>
     </div>

--- a/templates/_review_entry.html
+++ b/templates/_review_entry.html
@@ -1,6 +1,7 @@
 {% set book = review_entry.book %}
 {% set review = review_entry.review %}
 {% set slug = review_entry.slug %}
+{% set cover_dimensions = review_entry.derived_cover_info %}
 
 <style>
   {% include "_review_style.css" %}
@@ -12,7 +13,24 @@ id="review_preview_{{ slug }}">
   <a href="/reviews/{{ slug }}">
   {% endif %}
     <div class="book_thumbnail">
-      {% include "_book_cover.html" %}
+      <!--
+        This is a total fudge to make thumbnails be centred horizontally and vertically,
+        even if the book is wider than it is tall.
+
+        The two "thumbnail_helper" elements on either side have height 100% and are
+        vertically aligned, and then somehow the image picks it up.
+
+        See https://stackoverflow.com/a/7310398/1558022.  I had to add a helper on
+        both sides to stop it pushing the image towards the right edge.
+
+        -->
+      <span class="thumbnail_helper"></span>
+      {% if cover_dimensions.width > cover_dimensions.height %}
+        <img src="/thumbnails/{{ book.cover.name }}" style="width: 130px; height: {{ cover_dimensions.height * 130 }} / cover_dimensions.width | round}}px;">
+      {% else %}
+        <img src="/thumbnails/{{ book.cover.name }}" style="height: 130px; width: {{ cover_dimensions.width * 130 / cover_dimensions.height | round }}px;">
+      {% endif %}
+      <span class="thumbnail_helper"></span>
     </div>
 
     <div class="book_metadata">


### PR DESCRIPTION
This should reduce page churn on `/reviews` as a browser loads in all the images, because it can lay them all out upfront.

Closes https://github.com/alexwlchan/books.alexwlchan.net/issues/48