### PR TITLE
Allow specifying host/port on 'vfd serve'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## v1.4.0 - 2022-07-06
+
+Allow setting `--host` and `--port` as arguments to `vfd serve`.
+
+Also remove the automatic web server start from `add_review`.
+
 ## v1.3.14 - 2022-07-03
 
 Fix a bug where images would look misshapen if re-cropped while running `vfd serve`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,9 +255,33 @@ dependencies = [
  "atty",
  "bitflags",
  "strsim 0.8.0",
- "textwrap",
+ "textwrap 0.11.0",
  "unicode-width",
  "vec_map",
+]
+
+[[package]]
+name = "clap"
+version = "3.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "190814073e85d238f31ff738fcb0bf6910cedeb73376c87cd69291028966fd83"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "strsim 0.10.0",
+ "termcolor",
+ "textwrap 0.15.0",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -1687,6 +1711,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21326818e99cfe6ce1e524c2a805c189a99b5ae555a35d19f9a284b427d86afa"
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1703,7 +1733,7 @@ checksum = "cc96b13363b50f7c3f1e105fb7fe3e231a41ad1434fa1b055ed94b09b97ac786"
 dependencies = [
  "bit-vec",
  "byteorder",
- "clap",
+ "clap 2.34.0",
  "cloudflare-zlib",
  "crc 2.1.0",
  "crossbeam-channel",
@@ -2563,6 +2593,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
 name = "thiserror"
 version = "1.0.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2943,12 +2979,12 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vfd"
-version = "1.3.14"
+version = "1.4.0"
 dependencies = [
  "axum",
  "base64",
  "chrono",
- "clap",
+ "clap 3.2.8",
  "futures",
  "hotwatch",
  "html-minifier",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "vfd"
-version = "1.3.14"
+version = "1.4.0"
 edition = "2021"
 
 [dependencies]
 axum = "0.2"
 base64 = "0.13.0"
 chrono = "0.4.19"
-clap = "2.33"
+clap = "3.2.8"
 futures = "0.3"
 hotwatch = "0.4"
 html-minifier = "3.0.14"

--- a/src/add_review.rs
+++ b/src/add_review.rs
@@ -23,7 +23,7 @@ use crate::models;
 use crate::text_helpers;
 use crate::urls;
 
-pub fn subcommand() -> App<'static, 'static> {
+pub fn subcommand() -> App<'static> {
     SubCommand::with_name("add_review").about("Start a review of a new book")
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,8 +164,7 @@ async fn main() {
         std::process::exit(0);
     }
 
-    if matches.subcommand_name() == Some("add_review") || matches.subcommand_name() == Some("serve")
-    {
+    if matches.subcommand_name() == Some("serve") {
         crate::serve::run_server().await;
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-// #![deny(warnings)]
+#![deny(warnings)]
 
 /// This is a tool for generating the static files for my book tracker.
 ///

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,0 +1,68 @@
+use std::convert::Infallible;
+use std::net::SocketAddr;
+use std::thread;
+use std::time::Duration;
+
+use axum::{http::StatusCode, service, Router};
+use clap::{App, SubCommand};
+use tower_http::services::ServeDir;
+
+use crate::render_html::HtmlRenderMode;
+
+pub fn subcommand() -> App<'static, 'static> {
+    SubCommand::with_name("serve").about("Run a local web server with the site and live changes")
+}
+
+pub async fn run_server() -> () {
+    tokio::task::spawn_blocking(move || {
+        let mut hotwatch = hotwatch::Hotwatch::new().expect("hotwatch failed to initialize!");
+
+        hotwatch
+            .watch("covers", |_| {
+                crate::create_images();
+
+                // We need to recreate the HTML because the dimensions
+                // of the cover images get baked into the HTML; if we
+                // don't re-render then crops/dimensions may not update
+                // correctly.
+                crate::create_html_pages(HtmlRenderMode::Full);
+            })
+            .expect("failed to watch covers folder!");
+        hotwatch
+            .watch("reviews", |_| {
+                crate::create_html_pages(HtmlRenderMode::Incremental);
+            })
+            .expect("failed to watch reviews folder!");
+        hotwatch
+            .watch("static", |_| {
+                crate::create_static_files();
+            })
+            .expect("failed to watch static folder!");
+        hotwatch
+            .watch("templates", |_| {
+                crate::create_html_pages(HtmlRenderMode::Full);
+            })
+            .expect("failed to watch templates folder!");
+
+        loop {
+            thread::sleep(Duration::from_secs(1));
+        }
+    });
+
+    let app = Router::new().nest(
+        "/",
+        service::get(ServeDir::new("_html")).handle_error(|error: std::io::Error| {
+            Ok::<_, Infallible>((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Unhandled internal error: {}", error),
+            ))
+        }),
+    );
+
+    let addr = SocketAddr::from(([127, 0, 0, 1], 5959));
+    println!("🚀 Serving site on http://localhost:5959");
+    axum::Server::bind(&addr)
+        .serve(app.into_make_service())
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
This is so I can run on `0.0.0.0`, which will let me view a local web server on my iPhone and debug some iPhone-specific issues.

I've also updated the version of clap to v3, which turned out to be very easy – removing some lifetime parameters.