### PR TITLE
Use Srgb::from_str rather than my own hex-parsing code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v1.4.4 - 2022-08-07
+
+Present a full list of dominant colours for selection when using `vfd add_review`.
+
 ## v1.4.3 - 2022-07-31
 
 Improve the error message when the user presses Ctrl+C while using `vfd add_review`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2979,7 +2979,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vfd"
-version = "1.4.3"
+version = "1.4.4"
 dependencies = [
  "axum",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vfd"
-version = "1.4.3"
+version = "1.4.4"
 edition = "2021"
 
 [dependencies]

--- a/src/add_review.rs
+++ b/src/add_review.rs
@@ -222,7 +222,8 @@ pub fn add_review() -> InquireResult<()> {
     let hex_strings = output.split("\n").collect();
 
     let hs = Select::new("What's the tint colour?", hex_strings).prompt()?;
-    let tint_colour = hs.split(" ")
+    let tint_colour = hs
+        .split(" ")
         .collect::<Vec<&str>>()
         .last()
         .unwrap()

--- a/src/add_review.rs
+++ b/src/add_review.rs
@@ -14,12 +14,10 @@ use clap::{App, SubCommand};
 use inquire::error::InquireResult;
 use inquire::validator::StringValidator;
 use inquire::{DateSelect, Select, Text};
-use palette::{RelativeContrast, Srgb};
 use regex::Regex;
 use serde::Serialize;
 use url::Url;
 
-use crate::colours;
 use crate::models;
 use crate::text_helpers;
 use crate::urls;
@@ -215,53 +213,20 @@ pub fn add_review() -> InquireResult<()> {
         Command::new("dominant_colours")
             .arg(&cover_path)
             .arg("--max-colours=12")
-            .arg("--no-palette")
             .output()
             .unwrap()
             .stdout,
     )
     .unwrap();
 
-    let dominant_colours = output
-        .trim()
-        .split_ascii_whitespace()
-        .map(|line| colours::parse_hex_string(line));
+    let hex_strings = output.split("\n").collect();
 
-    let white_background: Srgb<f32> = Srgb::new(1.0, 1.0, 1.0);
-
-    let usable_colours = dominant_colours
-        .filter(|rgb| {
-            let f32_c = Srgb::<f32>::new(
-                rgb.red as f32 / 255.0,
-                rgb.green as f32 / 255.0,
-                rgb.blue as f32 / 255.0,
-            );
-            white_background.has_min_contrast_text(&f32_c)
-        })
-        .collect::<Vec<Srgb<u8>>>();
-
-    let tint_colour = match usable_colours.len() {
-        0 => String::from("#ffffff"),
-        1 => {
-            let c = usable_colours[0];
-            format!("#{:02x}{:02x}{:02x}", c.red, c.green, c.blue)
-        }
-        _ => {
-            let hex_strings = usable_colours
-                .into_iter()
-                .map(|c| {
-                    let hs = format!("#{:02x}{:02x}{:02x}", c.red, c.green, c.blue);
-                    format!("\x1B[38;2;{};{};{}m▇ {}\x1B[0m", c.red, c.green, c.blue, hs)
-                })
-                .collect::<Vec<String>>();
-            let hs = Select::new("What's the tint colour?", hex_strings).prompt()?;
-            hs.split(" ")
-                .collect::<Vec<&str>>()
-                .last()
-                .unwrap()
-                .replace("\x1B[0m", "")
-        }
-    };
+    let hs = Select::new("What's the tint colour?", hex_strings).prompt()?;
+    let tint_colour = hs.split(" ")
+        .collect::<Vec<&str>>()
+        .last()
+        .unwrap()
+        .replace("\x1B[0m", "");
 
     let cover = models::Cover {
         name: cover_name.to_string(),

--- a/src/colours.rs
+++ b/src/colours.rs
@@ -1,13 +1,9 @@
 use palette::Srgb;
+use std::str::FromStr;
 
 // Parses a hex string as an RGB tuple, e.g. #d01c11 ~> (208, 28, 17)
 //
 // This function assumes the hex string is correctly formatted.
 pub fn parse_hex_string(s: &str) -> Srgb<u8> {
-    // Can I just use Srgb::from_str here???
-    assert_eq!(s.len(), 7);
-    let r = u8::from_str_radix(&s[1..3], 16).unwrap();
-    let g = u8::from_str_radix(&s[3..5], 16).unwrap();
-    let b = u8::from_str_radix(&s[5..7], 16).unwrap();
-    Srgb::new(r, g, b)
+    Srgb::from_str(s).unwrap()
 }

--- a/src/colours.rs
+++ b/src/colours.rs
@@ -1,7 +1,7 @@
 use palette::Srgb;
 use std::str::FromStr;
 
-// Parses a hex string as an RGB tuple, e.g. #d01c11 ~> (208, 28, 17)
+// Parses a hex string as an RGB colour, e.g. #d01c11 ~> (208, 28, 17)
 //
 // This function assumes the hex string is correctly formatted.
 pub fn parse_hex_string(s: &str) -> Srgb<u8> {


### PR DESCRIPTION
This is a little more flexible, and means less code. Ideally I'd pass around an `Srgb<u8>` internally, but that means implementing custom Serde traits for serialise/deserialise, which seem like overkill.