### PR TITLE
Tidy up how the "jump to year" links work

### DIFF
--- a/templates/list_reviews.html
+++ b/templates/list_reviews.html
@@ -14,18 +14,19 @@
 {% block content %}
   <h2>books i&rsquo;ve read</h2>
 
-  <p>jump to:
-  {% set linked_year = "" %}
-  {% for review_entry in reviews %}
-    {% if review_entry|year_read != linked_year %}
-      {% if review_entry|year_read == 'another time' %}
-        <a href="#another_time">another time</a>
-      {% else %}
-        <a href="#year_{{ review_entry|year_read }}">{{ review_entry|year_read }}</a> /
+  <p id="jumpTo">
+    jump to:
+    {% set linked_year = "" %}
+    {% for review_entry in reviews %}
+      {% if review_entry|year_read != linked_year %}
+        {% if review_entry|year_read == 'another time' %}
+          <a href="#another_time">another time</a>
+        {% else %}
+          <a href="#year_{{ review_entry|year_read }}">{{ review_entry|year_read }}</a> /
+        {% endif %}
       {% endif %}
-    {% endif %}
-    {% set_global linked_year = review_entry|year_read %}
-  {% endfor %}
+      {% set_global linked_year = review_entry|year_read %}
+    {% endfor %}
   </p>
 
   {% set heading_year = "" %}

--- a/templates/list_reviews.html
+++ b/templates/list_reviews.html
@@ -16,16 +16,18 @@
 
   <p id="jumpTo">
     jump to:
-    {% set linked_year = "" %}
-    {% for review_entry in reviews %}
-      {% if review_entry|year_read != linked_year %}
-        {% if review_entry|year_read == 'another time' %}
-          <a href="#another_time">another time</a>
-        {% else %}
-          <a href="#year_{{ review_entry|year_read }}">{{ review_entry|year_read }}</a> /
-        {% endif %}
+
+    {% set_global years = [] %}
+    {% for rev in reviews %}
+        {% set_global years = years | concat(with=rev|year_read) %}
+    {% endfor %}
+
+    {% for y in years | unique %}
+      {% if y == 'another time' %}
+        <a href="#another_time">another time</a>
+      {% else %}
+        <a href="#year_{{ y }}">{{ y }}</a> /
       {% endif %}
-      {% set_global linked_year = review_entry|year_read %}
     {% endfor %}
   </p>
 

--- a/templates/list_reviews.html
+++ b/templates/list_reviews.html
@@ -24,9 +24,13 @@
 
     {% for y in years | unique %}
       {% if y == 'another time' %}
-        <a href="#another_time">another time</a>
+        <a data-jumpTo-year="{{ y }}" href="#another_time">another time</a>
       {% else %}
-        <a href="#year_{{ y }}">{{ y }}</a> /
+        <a data-jumpTo-year="{{ y }}" href="#year_{{ y }}">{{ y }}</a>
+      {% endif %}
+
+      {% if not loop.last %}
+        <span aria-hidden="true">/</span>
       {% endif %}
     {% endfor %}
   </p>

--- a/templates/list_reviews.html
+++ b/templates/list_reviews.html
@@ -24,9 +24,9 @@
 
     {% for y in years | unique %}
       {% if y == 'another time' %}
-        <a data-jumpTo-year="{{ y }}" href="#another_time">another time</a>
+        <a id="jumpTo-{{ y }}" href="#another_time">another time</a>
       {% else %}
-        <a data-jumpTo-year="{{ y }}" href="#year_{{ y }}">{{ y }}</a>
+        <a id="jumpTo-{{ y }}" href="#year_{{ y }}">{{ y }}</a>
       {% endif %}
 
       {% if not loop.last %}


### PR DESCRIPTION
* Rather than finding unique years manually, we can get Tera to do it for us
* Screen readers can skip the slashes
* Add an `id` to the links so they can be individually addressed (not yet, but for filters)