### PR TITLE
Slightly rejig the cover handling; add aspect-ratio to individual pages

### DIFF
--- a/src/_includes/book_cover.html
+++ b/src/_includes/book_cover.html
@@ -10,5 +10,5 @@
 
   -->
 <span class="thumbnail_helper"></span>
-<img src="/individual_covers/{{ year }}/{{ book.cover.name }}" alt="">
+<img src="/individual_covers/{{ year }}/{{ book.cover.name }}" alt="" style="aspect-ratio: {{ book.cover.width }} / {{ book.cover.height }}">
 <span class="thumbnail_helper"></span>

--- a/src/_includes/review_entry.html
+++ b/src/_includes/review_entry.html
@@ -10,7 +10,6 @@
 {% assign book = review_entry.book %}
 {% assign review = review_entry.review %}
 {% assign slug = review_entry.url | replace: "/", "_" %}
-{% assign cover_dimensions = review_entry | derived_cover_info %}
 
 <style type="x-text/scss">
   #rp_{{ slug }} {
@@ -41,7 +40,7 @@
     <div class="book_thumbnail">
       <img
         src="/thumbs/{{ review | year_read }}/{{ book.cover.name }}"
-        style="aspect-ratio: {{ cover_dimensions['width'] }} / {{ cover_dimensions['height'] }}; max-width: 110px; max-height: 130px;"
+        style="aspect-ratio: {{ book.cover.width }} / {{ book.cover.height }}; max-width: 110px; max-height: 130px;"
         alt=""
         loading="lazy"
       >

--- a/src/_plugins/associate_covers_with_md.rb
+++ b/src/_plugins/associate_covers_with_md.rb
@@ -13,6 +13,8 @@
 # It's as if I'd specified the cover name in the YAML front matter,
 # but I don't actually have to do that.
 
+require_relative 'pillow/get_image_info'
+
 Jekyll::Hooks.register :site, :post_read do |site|
   # Construct a hash that maps normalised name to original path,
   # e.g. if there's an image called src/covers/2023/white-fragility.jpg,
@@ -35,7 +37,12 @@ Jekyll::Hooks.register :site, :post_read do |site|
     slug = "#{year}/#{name}"
 
     if cover_image_names.include? slug
-      post.data['book']['cover']['name'] = File.basename(cover_image_names[slug])
+      this_cover = File.basename(cover_image_names[slug])
+      post.data['book']['cover']['name'] = this_cover
+
+      info = get_single_image_info("#{site.config['source']}/covers/#{year}/#{this_cover}")
+      post.data['book']['cover']['width'] = info['width']
+      post.data['book']['cover']['height'] = info['height']
     else
       puts "Can't find a cover image for #{post.path} (#{slug})"
     end

--- a/src/_plugins/index_helpers.rb
+++ b/src/_plugins/index_helpers.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require_relative 'css_helpers'
-require_relative 'pillow/get_image_info'
 
 module Jekyll
   module IndexHelpers
@@ -25,20 +24,6 @@ module Jekyll
       else
         review['date_read'].year.to_s
       end
-    end
-
-    def derived_cover_info(review_entry)
-      year = if review_entry['review']['date_read'].is_a? Date
-               review_entry['review']['date_read'].year
-             else
-               review_entry['review']['date_read'][0..3]
-             end
-
-      filename = review_entry['book']['cover']['name']
-
-      image = get_single_image_info("src/covers/#{year}/#{filename}")
-
-      { 'width' => image['width'], 'height' => image['height'] }
     end
 
     def credit_line(book)


### PR DESCRIPTION
Closes #104 

I didn't write a description on that ticket – I thought I saw images jumping around as they loaded in, but I can't reproduce it now. I already set an `aspect-ratio` style on those images!

This slightly tidies up the code that handles image dimensions so I only have to get it once, but otherwise there's not much to do on the original ticket. I'll close it for now and reopen it if I see the issue again.